### PR TITLE
バージョン2.0.5のリリース以降に見つかっていた不具合を一通り修正

### DIFF
--- a/OutlookOkan/Helpers/NativeMethods.cs
+++ b/OutlookOkan/Helpers/NativeMethods.cs
@@ -4,14 +4,14 @@ using System.Windows.Forms;
 
 namespace OutlookOkan.Helpers
 {
-    public class OfficeWin32Window : IWin32Window
+    public class NativeMethods : IWin32Window
     {
         [DllImport("user32", CharSet = CharSet.Unicode)]
         private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
 
         public IntPtr Handle { get; }
 
-        public OfficeWin32Window(object windowObject)
+        public NativeMethods(object windowObject)
         {
             Handle = FindWindow("rctrl_renwnd32\0", windowObject.GetType().InvokeMember("Caption", System.Reflection.BindingFlags.GetProperty, null, windowObject, null).ToString());
         }

--- a/OutlookOkan/Helpers/OfficeWin32Window.cs
+++ b/OutlookOkan/Helpers/OfficeWin32Window.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace OutlookOkan.Helpers
+{
+    public class OfficeWin32Window : IWin32Window
+    {
+        [DllImport("user32", CharSet = CharSet.Unicode)]
+        private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+        public IntPtr Handle { get; }
+
+        public OfficeWin32Window(object windowObject)
+        {
+            Handle = FindWindow("rctrl_renwnd32\0", windowObject.GetType().InvokeMember("Caption", System.Reflection.BindingFlags.GetProperty, null, windowObject, null).ToString());
+        }
+    }
+}

--- a/OutlookOkan/OutlookOkan.csproj
+++ b/OutlookOkan/OutlookOkan.csproj
@@ -29,11 +29,13 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <DefineConstants>VSTO40</DefineConstants>
     <IsWebBootstrapper>False</IsWebBootstrapper>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <PublishUrl>publish\</PublishUrl>
     <InstallUrl />
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>2.0.5.0</ApplicationVersion>
+    <ApplicationVersion>2.0.6.0</ApplicationVersion>
     <AutoIncrementApplicationRevision>true</AutoIncrementApplicationRevision>
     <UpdateEnabled>false</UpdateEnabled>
     <UpdateInterval>0</UpdateInterval>
@@ -120,13 +122,12 @@
     <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <!--
     This section specifies references for the project.
   -->
   <ItemGroup>
-    <Reference Include="Accessibility" />
     <Reference Include="CsvHelper, Version=7.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.7.1.1\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
@@ -139,18 +140,15 @@
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
     </Reference>
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
     </Reference>
@@ -160,7 +158,6 @@
     <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
     </Reference>
@@ -170,13 +167,12 @@
     <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
     </Reference>
-    <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
     </Reference>
@@ -193,7 +189,7 @@
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
@@ -201,18 +197,16 @@
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.1\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
     </Reference>
     <Reference Include="Ude.NetStandard, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Ude.NetStandard.1.0.1\lib\netstandard1.0\Ude.NetStandard.dll</HintPath>
@@ -220,9 +214,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Office.Tools.v4.0.Framework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Tools.Applications.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
@@ -253,9 +244,6 @@
       <Private>False</Private>
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
-    <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <!--
     This section defines the user source files that are part of the project.
@@ -271,7 +259,7 @@
     <Compile Include="CsvTools\CsvImportAndExport.cs" />
     <Compile Include="CsvTools\CsvToolsBase.cs" />
     <Compile Include="CsvTools\ReadAndWriteCsv.cs" />
-    <Compile Include="Helpers\OfficeWin32Window.cs" />
+    <Compile Include="Helpers\NativeMethods.cs" />
     <Compile Include="Models\GenerateCheckList.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
@@ -393,4 +381,11 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
+  </Target>
 </Project>

--- a/OutlookOkan/OutlookOkan.csproj
+++ b/OutlookOkan/OutlookOkan.csproj
@@ -271,6 +271,7 @@
     <Compile Include="CsvTools\CsvImportAndExport.cs" />
     <Compile Include="CsvTools\CsvToolsBase.cs" />
     <Compile Include="CsvTools\ReadAndWriteCsv.cs" />
+    <Compile Include="Helpers\OfficeWin32Window.cs" />
     <Compile Include="Models\GenerateCheckList.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>

--- a/OutlookOkan/Properties/AssemblyInfo.cs
+++ b/OutlookOkan/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.5.0")]
-[assembly: AssemblyFileVersion("2.0.5.0")]
+[assembly: AssemblyVersion("2.0.6.0")]
+[assembly: AssemblyFileVersion("2.0.6.0")]
 [assembly: NeutralResourcesLanguage("en-US")]
 

--- a/OutlookOkan/Properties/Resources.Designer.cs
+++ b/OutlookOkan/Properties/Resources.Designer.cs
@@ -914,7 +914,7 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version 2.0.5.
+        ///   Looks up a localized string similar to Version 2.0.6.
         /// </summary>
         public static string Version {
             get {

--- a/OutlookOkan/Properties/Resources.ja-JP.resx
+++ b/OutlookOkan/Properties/Resources.ja-JP.resx
@@ -361,7 +361,7 @@
     <value>Copyright (C) 2018 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>バージョン 2.0.5</value>
+    <value>バージョン 2.0.6</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>バージョン情報</value>

--- a/OutlookOkan/Properties/Resources.resx
+++ b/OutlookOkan/Properties/Resources.resx
@@ -361,7 +361,7 @@
     <value>Copyright (C) 2018 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.0.5</value>
+    <value>Version 2.0.6</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>About</value>

--- a/OutlookOkan/Ribbon.cs
+++ b/OutlookOkan/Ribbon.cs
@@ -1,9 +1,11 @@
-﻿using OutlookOkan.Views;
+﻿using OutlookOkan.Helpers;
+using OutlookOkan.Views;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Windows.Interop;
 using Office = Microsoft.Office.Core;
 
 namespace OutlookOkan
@@ -23,12 +25,20 @@ namespace OutlookOkan
         public void ShowSettings(Office.IRibbonControl control)
         {
             var settingsWindow = new SettingsWindow();
+            var activeWindow = Globals.ThisAddIn.Application.ActiveWindow();
+            var outlookHandle = new OfficeWin32Window(activeWindow).Handle;
+            var windowInteropHelper = new WindowInteropHelper(settingsWindow) { Owner = outlookHandle };
+
             settingsWindow.ShowDialog();
         }
 
         public void ShowAbout(Office.IRibbonControl control)
         {
             var aboutWindow = new AboutWindow();
+            var activeWindow = Globals.ThisAddIn.Application.ActiveWindow();
+            var outlookHandle = new OfficeWin32Window(activeWindow).Handle;
+            var windowInteropHelper = new WindowInteropHelper(aboutWindow) { Owner = outlookHandle };
+
             aboutWindow.ShowDialog();
         }
 

--- a/OutlookOkan/Services/ResourceService.cs
+++ b/OutlookOkan/Services/ResourceService.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace OutlookOkan.Services
 {
-    class ResourceService : INotifyPropertyChanged
+    internal class ResourceService : INotifyPropertyChanged
     {
         // Singleton instance.
         public static ResourceService Instance { get; } = new ResourceService();

--- a/OutlookOkan/ThisAddIn.cs
+++ b/OutlookOkan/ThisAddIn.cs
@@ -38,7 +38,7 @@ namespace OutlookOkan
 
             Application.ItemSend += Application_ItemSend;
         }
-        
+
         private void Application_ItemSend(object item, ref bool cancel)
         {
             //MailItemにキャストできないものは会議招待などメールではないものなので、何もしない。
@@ -48,7 +48,7 @@ namespace OutlookOkan
             try
             {
                 var generateCheckList = new GenerateCheckList();
-                var checklist = generateCheckList.GenerateCheckListFromMail((Outlook._MailItem) item);
+                var checklist = generateCheckList.GenerateCheckListFromMail((Outlook._MailItem)item);
 
                 //Outlook起動後にユーザが設定を変更する可能性があるため、毎回ユーザ設定をロード
                 LoadSetting();
@@ -106,7 +106,7 @@ namespace OutlookOkan
                     //OutlookのWindowを親として確認画面をモーダル表示。
                     var confirmationWindow = new ConfirmationWindow(checklist);
                     var activeWindow = Globals.ThisAddIn.Application.ActiveWindow();
-                    var outlookHandle = new OfficeWin32Window(activeWindow).Handle;
+                    var outlookHandle = new NativeMethods(activeWindow).Handle;
                     var windowInteropHelper = new WindowInteropHelper(confirmationWindow) { Owner = outlookHandle };
 
                     var dialogResult = confirmationWindow.ShowDialog();
@@ -125,9 +125,9 @@ namespace OutlookOkan
                     //Send Mail.
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                var dialogResult = MessageBox.Show(Properties.Resources.SendMailConfirmation, Properties.Resources.IsCanNotShowConfirmation, MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                var dialogResult = MessageBox.Show(Properties.Resources.IsCanNotShowConfirmation + Environment.NewLine + Properties.Resources.SendMailConfirmation + Environment.NewLine + Environment.NewLine + e.Message, Properties.Resources.IsCanNotShowConfirmation, MessageBoxButton.YesNo, MessageBoxImage.Warning);
                 if (dialogResult == MessageBoxResult.Yes)
                 {
                     //SendMail
@@ -211,14 +211,7 @@ namespace OutlookOkan
 
         #region VSTO generated code
 
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
-        private void InternalStartup()
-        {
-            Startup += ThisAddIn_Startup;
-        }
+        private void InternalStartup() => Startup += ThisAddIn_Startup;
 
         #endregion
     }

--- a/OutlookOkan/ThisAddIn.cs
+++ b/OutlookOkan/ThisAddIn.cs
@@ -1,4 +1,5 @@
 ﻿using OutlookOkan.CsvTools;
+using OutlookOkan.Helpers;
 using OutlookOkan.Models;
 using OutlookOkan.Services;
 using OutlookOkan.Types;
@@ -7,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Interop;
 using MessageBox = System.Windows.MessageBox;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
@@ -101,7 +103,12 @@ namespace OutlookOkan
                 //確認画面の表示条件に合致していたら
                 else if (IsShowConfirmationWindow(checklist))
                 {
+                    //OutlookのWindowを親として確認画面をモーダル表示。
                     var confirmationWindow = new ConfirmationWindow(checklist);
+                    var activeWindow = Globals.ThisAddIn.Application.ActiveWindow();
+                    var outlookHandle = new OfficeWin32Window(activeWindow).Handle;
+                    var windowInteropHelper = new WindowInteropHelper(confirmationWindow) { Owner = outlookHandle };
+
                     var dialogResult = confirmationWindow.ShowDialog();
 
                     if (dialogResult == true)

--- a/OutlookOkan/Views/ConfirmationWindow.xaml
+++ b/OutlookOkan/Views/ConfirmationWindow.xaml
@@ -8,7 +8,7 @@
              xmlns:services="clr-namespace:OutlookOkan.Services"
              mc:Ignorable="d"
         Title="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Confirmation, Mode=OneWay}"
-        ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" Height="570" Width="780">
+        ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" Height="590" Width="780">
     <StackPanel Margin="5,8">
         <StackPanel Margin="5,0,0,0">
             <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ConfirmationMessage1, Mode=OneWay}" FontSize="12" Padding="0"/>
@@ -113,7 +113,7 @@
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTextColumn Binding="{Binding MailAddress, Mode=OneWay}" Width="*" IsReadOnly="True" Foreground="{Binding Foreground, Mode=OneWay}">
+                                <DataGridTextColumn Binding="{Binding MailAddress, Mode=OneWay}" Width="*" IsReadOnly="True">
                                     <DataGridTextColumn.CellStyle>
                                         <Style TargetType="DataGridCell">
                                             <Style.Triggers>

--- a/OutlookOkan/Views/ConfirmationWindow.xaml.cs
+++ b/OutlookOkan/Views/ConfirmationWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace OutlookOkan.Views
         private void ToggleButton_OnChecked(object sender, RoutedEventArgs e)
         {
             var viewModel = DataContext as ConfirmationWindowViewModel;
-            viewModel.ToggleSendButton();
+            viewModel?.ToggleSendButton();
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace OutlookOkan.Views
         private void ToggleButton_OnUnchecked(object sender, RoutedEventArgs e)
         {
             var viewModel = DataContext as ConfirmationWindowViewModel;
-            viewModel.ToggleSendButton();
+            viewModel?.ToggleSendButton();
         }
     }
 }

--- a/OutlookOkan/Views/SettingsWindow.xaml
+++ b/OutlookOkan/Views/SettingsWindow.xaml
@@ -81,7 +81,7 @@
                     <GridSplitter Grid.Column="1"/>
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleWhiteList, Mode=OneWay}" Padding="0,12,0,0"/>
+                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleWhiteList, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
@@ -124,7 +124,7 @@
                     <GridSplitter Grid.Column="1"/>
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleNameAndDomain, Mode=OneWay}" Padding="0,12,0,0"/>
+                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleNameAndDomain, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
@@ -176,7 +176,7 @@
                     <GridSplitter Grid.Column="1"/>
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertKeyword, Mode=OneWay}" Padding="0,12,0,0"/>
+                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertKeyword, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
@@ -221,7 +221,7 @@
                     <GridSplitter Grid.Column="1"/>
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertMailAddress, Mode=OneWay}" Padding="0,12,0,0"/>
+                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertMailAddress, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
@@ -272,7 +272,7 @@
                     <GridSplitter Grid.Column="1"/>
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByKeyword, Mode=OneWay}" Padding="0,12,0,0"/>
+                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByKeyword, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
@@ -323,7 +323,7 @@
                     <GridSplitter Grid.Column="1"/>
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByMailAddressOrDomain, Mode=OneWay}" Padding="0,12,0,0"/>
+                            <TextBox Height="220" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByMailAddressOrDomain, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">

--- a/OutlookOkan/Views/SettingsWindow.xaml.cs
+++ b/OutlookOkan/Views/SettingsWindow.xaml.cs
@@ -84,7 +84,7 @@ namespace OutlookOkan.Views
         private void OkButton_OnClick(object sender, RoutedEventArgs e)
         {
             var viewModel = DataContext as SettingsWindowViewModel;
-            viewModel.SaveSettings();
+            viewModel?.SaveSettings();
 
             DialogResult = true;
         }
@@ -97,7 +97,7 @@ namespace OutlookOkan.Views
         private void ApplyButton_OnClick(object sender, RoutedEventArgs e)
         {
             var viewModel = DataContext as SettingsWindowViewModel;
-            viewModel.SaveSettings();
+            viewModel?.SaveSettings();
 
             MessageBox.Show(Properties.Resources.SaveSettings);
         }

--- a/OutlookOkan/packages.config
+++ b/OutlookOkan/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="7.1.1" targetFramework="net462" />
-  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.NETCore.Platforms" version="2.1.1" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
+  <package id="NETStandard.Library" version="2.0.3" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net462" />
-  <package id="System.Console" version="4.3.0" targetFramework="net462" />
+  <package id="System.Console" version="4.3.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
@@ -21,7 +21,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />
@@ -35,17 +35,17 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net462" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net462" />
   <package id="System.Threading" version="4.3.0" targetFramework="net462" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net462" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net462" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net462" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net462" />
   <package id="Ude.NetStandard" version="1.0.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
■全般
・送信禁止の宛先としてドメインを指定した場合、正しく判定されない問題を修正。
・確認画面や設定画面が隠れないよう、常にOutlookの上に表示されるように変更。
・何らかのエラーで確認画面が表示できない場合、エラー内容を表示するように変更。


■確認画面
・本文や件名が空白の場合に、確認画面が表示されずエラーが表示された問題を修正。
・メール本文のプレビューに不要な改行が入る場合がある問題を修正。
・Windows 7で、送信やキャンセルのボタンの一部が隠れてしまう場合がある問題を修正。
(確認ウインドウを縦に少し大きくしました)
・内部的なエラー処理を改善し、エラーによる確認画面の非表示をできる限り回避。


■設定画面
・設定画面の設定例が編集できてしまう問題を修正。
