### PR TITLE
確認画面と設定画面の改善

### DIFF
--- a/OutlookOkan/CsvTools/CsvImportAndExport.cs
+++ b/OutlookOkan/CsvTools/CsvImportAndExport.cs
@@ -9,7 +9,7 @@ using System.Windows.Forms;
 namespace OutlookOkan.CsvTools
 {
     //TODO To be improved
-    public class CsvImportAndExport : CsvToolsBase
+    public sealed class CsvImportAndExport : CsvToolsBase
     {
         private Encoding _fileEncoding;
 

--- a/OutlookOkan/CsvTools/ReadAndWriteCsv.cs
+++ b/OutlookOkan/CsvTools/ReadAndWriteCsv.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace OutlookOkan.CsvTools
 {
-    public class ReadAndWriteCsv : CsvToolsBase
+    public sealed class ReadAndWriteCsv : CsvToolsBase
     {
         /// <summary>
         /// 設定ファイル(CSV)の設置個所は下記で固定。

--- a/OutlookOkan/Helpers/NativeMethods.cs
+++ b/OutlookOkan/Helpers/NativeMethods.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace OutlookOkan.Helpers
 {
-    public class NativeMethods : IWin32Window
+    public sealed class NativeMethods : IWin32Window
     {
         [DllImport("user32", CharSet = CharSet.Unicode)]
         private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);

--- a/OutlookOkan/Models/GenerateCheckList.cs
+++ b/OutlookOkan/Models/GenerateCheckList.cs
@@ -9,7 +9,7 @@ using Outlook = Microsoft.Office.Interop.Outlook;
 
 namespace OutlookOkan.Models
 {
-    public class GenerateCheckList
+    public sealed class GenerateCheckList
     {
         private readonly CheckList _checkList = new CheckList();
 

--- a/OutlookOkan/OutlookOkan.csproj
+++ b/OutlookOkan/OutlookOkan.csproj
@@ -35,7 +35,7 @@
     <PublishUrl>publish\</PublishUrl>
     <InstallUrl />
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>2.2.0.1</ApplicationVersion>
+    <ApplicationVersion>2.2.1.0</ApplicationVersion>
     <AutoIncrementApplicationRevision>false</AutoIncrementApplicationRevision>
     <UpdateEnabled>false</UpdateEnabled>
     <UpdateInterval>0</UpdateInterval>

--- a/OutlookOkan/Properties/AssemblyInfo.cs
+++ b/OutlookOkan/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.1")]
-[assembly: AssemblyFileVersion("2.2.0.1")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]
 [assembly: NeutralResourcesLanguage("en-US")]
 

--- a/OutlookOkan/Properties/Resources.Designer.cs
+++ b/OutlookOkan/Properties/Resources.Designer.cs
@@ -1031,7 +1031,7 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version 2.2.0.1.
+        ///   Looks up a localized string similar to Version 2.2.1.
         /// </summary>
         public static string Version {
             get {

--- a/OutlookOkan/Properties/Resources.ja-JP.resx
+++ b/OutlookOkan/Properties/Resources.ja-JP.resx
@@ -361,7 +361,7 @@
     <value>Copyright (C) 2019 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>バージョン 2.2.0.1</value>
+    <value>バージョン 2.2.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>バージョン情報</value>

--- a/OutlookOkan/Properties/Resources.resx
+++ b/OutlookOkan/Properties/Resources.resx
@@ -361,7 +361,7 @@
     <value>Copyright (C) 2019 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.2.0.1</value>
+    <value>Version 2.2.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>About</value>

--- a/OutlookOkan/Types/AlertAddress.cs
+++ b/OutlookOkan/Types/AlertAddress.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class AlertAddress
+    public sealed class AlertAddress
     {
         public string TartgetAddress { get; set; }
         public bool IsCanNotSend { get; set; }

--- a/OutlookOkan/Types/AlertKeywordAndMessage.cs
+++ b/OutlookOkan/Types/AlertKeywordAndMessage.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class AlertKeywordAndMessage
+    public sealed class AlertKeywordAndMessage
     {
         public string AlertKeyword { get; set; }
         public string Message { get; set; }

--- a/OutlookOkan/Types/AutoCcBccKeyword.cs
+++ b/OutlookOkan/Types/AutoCcBccKeyword.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class AutoCcBccKeyword
+    public sealed class AutoCcBccKeyword
     {
         public string Keyword { get; set; }
         public CcOrBcc CcOrBcc { get; set; }

--- a/OutlookOkan/Types/AutoCcBccRecipient.cs
+++ b/OutlookOkan/Types/AutoCcBccRecipient.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class AutoCcBccRecipient
+    public sealed class AutoCcBccRecipient
     {
         public string TargetRecipient { get; set; }
         public CcOrBcc CcOrBcc { get; set; }

--- a/OutlookOkan/Types/CheckList.cs
+++ b/OutlookOkan/Types/CheckList.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class CheckList
+    public sealed class CheckList
     {
         public List<Alert> Alerts { get; set; } = new List<Alert>();
         public List<Address> ToAddresses { get; set; } = new List<Address>();
@@ -21,7 +21,7 @@ namespace OutlookOkan.Types
         public int DeferredMinutes { get; set; }
     }
 
-    public class Alert
+    public sealed class Alert
     {
         public string AlertMessage { get; set; }
         public bool IsImportant { get; set; }
@@ -29,7 +29,7 @@ namespace OutlookOkan.Types
         public bool IsChecked { get; set; }
     }
 
-    public class Attachment
+    public sealed class Attachment
     {
         public string FileName { get; set; }
         public string FileType { get; set; }
@@ -40,7 +40,7 @@ namespace OutlookOkan.Types
         public bool IsChecked { get; set; }
     }
 
-    public class Address
+    public sealed class Address
     {
         public string MailAddress { get; set; }
         public bool IsExternal { get; set; }

--- a/OutlookOkan/Types/DeferredDeliveryMinutes.cs
+++ b/OutlookOkan/Types/DeferredDeliveryMinutes.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class DeferredDeliveryMinutes
+    public sealed class DeferredDeliveryMinutes
     {
         public string TartgetAddress { get; set; }
         public int DeferredMinutes { get; set; }

--- a/OutlookOkan/Types/GeneralSetting.cs
+++ b/OutlookOkan/Types/GeneralSetting.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class GeneralSetting
+    public sealed class GeneralSetting
     {
         public bool IsDoNotConfirmationIfAllRecipientsAreSameDomain { get; set; }
         public bool IsDoDoNotConfirmationIfAllWhite { get; set; }

--- a/OutlookOkan/Types/Languages.cs
+++ b/OutlookOkan/Types/Languages.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class Languages
+    public sealed class Languages
     {
         public List<LanguageCodeAndName> Language = new List<LanguageCodeAndName>();
 
@@ -13,7 +13,7 @@ namespace OutlookOkan.Types
         }
     }
 
-    public class LanguageCodeAndName
+    public sealed class LanguageCodeAndName
     {
         public int LanguageNumber { get; set; }
         public string LanguageCode { get; set; }

--- a/OutlookOkan/Types/NameAndDomains.cs
+++ b/OutlookOkan/Types/NameAndDomains.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class NameAndDomains
+    public sealed class NameAndDomains
     {
         public string Name { get; set; }
         public string Domain { get; set; }

--- a/OutlookOkan/Types/NameAndRecipient.cs
+++ b/OutlookOkan/Types/NameAndRecipient.cs
@@ -1,6 +1,6 @@
 ﻿namespace OutlookOkan.Types
 {
-    public class NameAndRecipient
+    public sealed class NameAndRecipient
     {
         public string MailAddress { get; set; }
         public string NameAndMailAddress { get; set; }

--- a/OutlookOkan/Types/Whitelist.cs
+++ b/OutlookOkan/Types/Whitelist.cs
@@ -2,7 +2,7 @@
 
 namespace OutlookOkan.Types
 {
-    public class Whitelist
+    public sealed class Whitelist
     {
         public string WhiteName { get; set; }
         public bool IsSkipConfirmation { get; set; }

--- a/OutlookOkan/ViewModels/ConfirmationWindowViewModel.cs
+++ b/OutlookOkan/ViewModels/ConfirmationWindowViewModel.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace OutlookOkan.ViewModels
 {
-    public class ConfirmationWindowViewModel : ViewModelBase
+    public sealed class ConfirmationWindowViewModel : ViewModelBase
     {
         public ConfirmationWindowViewModel(CheckList checkList)
         {

--- a/OutlookOkan/ViewModels/RelayCommand.cs
+++ b/OutlookOkan/ViewModels/RelayCommand.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace OutlookOkan.ViewModels
 {
-    public class RelayCommand : ICommand
+    public sealed class RelayCommand : ICommand
     {
         private readonly Action _execute;
         private readonly Func<bool> _canExecute;

--- a/OutlookOkan/ViewModels/SettingsWindowViewModel.cs
+++ b/OutlookOkan/ViewModels/SettingsWindowViewModel.cs
@@ -12,7 +12,7 @@ using System.Windows.Input;
 
 namespace OutlookOkan.ViewModels
 {
-    public class SettingsWindowViewModel : ViewModelBase
+    public sealed class SettingsWindowViewModel : ViewModelBase
     {
         public SettingsWindowViewModel()
         {

--- a/OutlookOkan/Views/AboutWindow.xaml
+++ b/OutlookOkan/Views/AboutWindow.xaml
@@ -12,23 +12,23 @@
     <StackPanel Margin="5,8">
         <Grid Height="315">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="4*"/>
+                <ColumnDefinition Width="4*" />
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="6*"/>
+                <ColumnDefinition Width="6*" />
             </Grid.ColumnDefinitions>
             <StackPanel Grid.Column="0" Margin="8,2,8,8">
-                <Image Source="/OutlookOkan;component/Images/Noraneko_Logo.png" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="6,50,6,0" RenderOptions.BitmapScalingMode="Fant"/>
+                <Image Source="/OutlookOkan;component/Images/Noraneko_Logo.png" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="6,50,6,0" RenderOptions.BitmapScalingMode="Fant" />
             </StackPanel>
-            <GridSplitter Grid.Column="1"/>
+            <GridSplitter Grid.Column="1" />
             <StackPanel Grid.Column="2" Margin="8,2,8,8">
-                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AppName, Mode=OneWay}"/>
-                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Version, Mode=OneWay}"/>
-                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Copyright, Mode=OneWay}"/>
-                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CompanyName, Mode=OneWay}"/>
+                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AppName, Mode=OneWay}" />
+                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Version, Mode=OneWay}" />
+                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Copyright, Mode=OneWay}" />
+                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CompanyName, Mode=OneWay}" />
 
-                <TextBox Height="150" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Visible" IsReadOnly="True" Margin="0,3,0,0" Padding="3" Text="Third-Party Software Usage and Licenses&#xA;&#xA;CsvHelper (CsvHelper.dll)&#xA;Copyright © 2009-2019 Josh Close and Contributors&#xA;Dual licensed under Microsoft Public License and Apache License Version 2.0&#xA;https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt&#xA;&#xA;Ude.NetStandard (Ude.NetStandard.dll)&#xA;The library is subject to the Mozilla Public License Version 1.1 (the &quot;License&quot;).&#xA;Alternatively, it may be used under the terms of either the GNU General Public License Version 2 or later (the &quot;GPL&quot;),&#xA;or the GNU Lesser General Public License Version 2.1 or later (the &quot;LGPL&quot;).&#xA;License&#xA;https://github.com/yinyue200/ude/tree/master/license&#xA;Source code&#xA;https://github.com/yinyue200/ude&#xA;&#xA;System.ValueTuple (System.ValueTuple.dll)&#xA;The MIT License (MIT)&#xA;Copyright (c) .NET Foundation and Contributors&#xA;https://github.com/dotnet/corefx/blob/master/LICENSE.TXT&#xA;  "/>
+                <TextBox Height="150" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Visible" IsReadOnly="True" Margin="0,3,0,0" Padding="3" Text="Third-Party Software Usage and Licenses&#xA;&#xA;CsvHelper (CsvHelper.dll)&#xA;Copyright © 2009-2019 Josh Close and Contributors&#xA;Dual licensed under Microsoft Public License and Apache License Version 2.0&#xA;https://github.com/JoshClose/CsvHelper/blob/master/LICENSE.txt&#xA;&#xA;Ude.NetStandard (Ude.NetStandard.dll)&#xA;The library is subject to the Mozilla Public License Version 1.1 (the &quot;License&quot;).&#xA;Alternatively, it may be used under the terms of either the GNU General Public License Version 2 or later (the &quot;GPL&quot;),&#xA;or the GNU Lesser General Public License Version 2.1 or later (the &quot;LGPL&quot;).&#xA;License&#xA;https://github.com/yinyue200/ude/tree/master/license&#xA;Source code&#xA;https://github.com/yinyue200/ude&#xA;&#xA;System.ValueTuple (System.ValueTuple.dll)&#xA;The MIT License (MIT)&#xA;Copyright (c) .NET Foundation and Contributors&#xA;https://github.com/dotnet/corefx/blob/master/LICENSE.TXT&#xA;  " />
 
-                <Button Content="OK" Width="100" HorizontalAlignment="Right" Margin="0,13,5,0" IsCancel="True" IsDefault="True"/>
+                <Button Content="OK" Width="100" HorizontalAlignment="Right" Margin="0,13,5,0" IsCancel="True" IsDefault="True" />
             </StackPanel>
         </Grid>
     </StackPanel>

--- a/OutlookOkan/Views/ConfirmationWindow.xaml
+++ b/OutlookOkan/Views/ConfirmationWindow.xaml
@@ -215,7 +215,7 @@
                     </StackPanel>
                 </GroupBox>
             </StackPanel>
-            <GridSplitter Grid.Column="1"/>
+            <GridSplitter Grid.Column="1" IsTabStop="False"/>
             <StackPanel Grid.Column="2" Margin="0,2,8,0">
                 <GroupBox Header="{Binding AttachmentCount}"  FontSize="11" Padding="3,3,3,3">
                     <DataGrid Height="68" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding Attachments,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" >

--- a/OutlookOkan/Views/ConfirmationWindow.xaml
+++ b/OutlookOkan/Views/ConfirmationWindow.xaml
@@ -24,19 +24,32 @@
                                     <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
+                            <DataGridTemplateColumn.CellStyle>
+                                <Style TargetType="DataGridCell">
+                                    <Setter Property="IsTabStop" Value="False"/>
+                                </Style>
+                            </DataGridTemplateColumn.CellStyle>
                         </DataGridTemplateColumn>
                         <DataGridTextColumn Binding="{Binding AlertMessage, Mode=OneWay}" Width="*" IsReadOnly="True">
                             <DataGridTextColumn.CellStyle>
                                 <Style TargetType="DataGridCell">
+                                    <Setter Property="IsTabStop" Value="False"/>
                                     <Style.Triggers>
-                                        <DataTrigger Binding="{Binding IsImportant}" Value="true">
+                                        <DataTrigger Binding="{Binding IsImportant}" Value="True">
                                             <Setter Property="Foreground" Value="#FFFF2800"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding IsImportant}" Value="False">
+                                            <Setter Property="Foreground" Value="Black"/>
                                         </DataTrigger>
                                     </Style.Triggers>
                                 </Style>
                             </DataGridTextColumn.CellStyle>
                         </DataGridTextColumn>
                     </DataGrid.Columns>
+                    <DataGrid.Resources>
+                        <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Transparent" />
+                        <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent" />
+                    </DataGrid.Resources>
                 </DataGrid>
             </GroupBox>
         </StackPanel>
@@ -58,6 +71,11 @@
                                             <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center"  Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
+                                    <DataGridTemplateColumn.CellStyle>
+                                        <Style TargetType="DataGridCell">
+                                            <Setter Property="IsTabStop" Value="False"/>
+                                        </Style>
+                                    </DataGridTemplateColumn.CellStyle>
                                 </DataGridTemplateColumn>
                                 <DataGridTextColumn Binding="{Binding MailAddress, Mode=OneWay}" Width="*" IsReadOnly="True">
                                     <DataGridTextColumn.CellStyle>
@@ -65,17 +83,34 @@
                                             <Style.Triggers>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding IsExternal}" Value="true" />
-                                                        <Condition Binding="{Binding IsWhite}" Value="false" />
+                                                        <Condition Binding="{Binding IsExternal}" Value="True" />
+                                                        <Condition Binding="{Binding IsWhite}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
                                                     <Setter Property="Foreground" Value="#FFFF2800" />
                                                 </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsExternal}" Value="False" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsWhite}" Value="True"/>
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </MultiDataTrigger>
                                             </Style.Triggers>
                                             <Setter Property="ToolTip" Value="{Binding MailAddress, Mode=OneWay}" />
+                                            <Setter Property="IsTabStop" Value="False"/>
                                         </Style>
                                     </DataGridTextColumn.CellStyle>
                                 </DataGridTextColumn>
                             </DataGrid.Columns>
+                            <DataGrid.Resources>
+                                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Transparent" />
+                                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent" />
+                            </DataGrid.Resources>
                         </DataGrid>
                         <Label Content="{Binding CcAddressCount}" Margin="0,6,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11"/>
                         <DataGrid Height="70" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding CcAddresses,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" >
@@ -86,6 +121,11 @@
                                             <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
+                                    <DataGridTemplateColumn.CellStyle>
+                                        <Style TargetType="DataGridCell">
+                                            <Setter Property="IsTabStop" Value="False"/>
+                                        </Style>
+                                    </DataGridTemplateColumn.CellStyle>
                                 </DataGridTemplateColumn>
                                 <DataGridTextColumn Binding="{Binding MailAddress, Mode=OneWay}" Width="*" IsReadOnly="True">
                                     <DataGridTextColumn.CellStyle>
@@ -93,17 +133,34 @@
                                             <Style.Triggers>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding IsExternal}" Value="true" />
-                                                        <Condition Binding="{Binding IsWhite}" Value="false"/>
+                                                        <Condition Binding="{Binding IsExternal}" Value="True" />
+                                                        <Condition Binding="{Binding IsWhite}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
                                                     <Setter Property="Foreground" Value="#FFFF2800"/>
                                                 </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsExternal}" Value="False" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsWhite}" Value="True"/>
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </MultiDataTrigger>
                                             </Style.Triggers>
                                             <Setter Property="ToolTip" Value="{Binding MailAddress, Mode=OneWay}" />
+                                            <Setter Property="IsTabStop" Value="False"/>
                                         </Style>
                                     </DataGridTextColumn.CellStyle>
                                 </DataGridTextColumn>
                             </DataGrid.Columns>
+                            <DataGrid.Resources>
+                                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Transparent" />
+                                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent" />
+                            </DataGrid.Resources>
                         </DataGrid>
                         <Label Content="{Binding BccAddressCount}" Margin="0,6,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11"/>
                         <DataGrid Height="70" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding BccAddresses,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" >
@@ -114,6 +171,11 @@
                                             <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
+                                    <DataGridTemplateColumn.CellStyle>
+                                        <Style TargetType="DataGridCell">
+                                            <Setter Property="IsTabStop" Value="False"/>
+                                        </Style>
+                                    </DataGridTemplateColumn.CellStyle>
                                 </DataGridTemplateColumn>
                                 <DataGridTextColumn Binding="{Binding MailAddress, Mode=OneWay}" Width="*" IsReadOnly="True">
                                     <DataGridTextColumn.CellStyle>
@@ -121,17 +183,34 @@
                                             <Style.Triggers>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding IsExternal}" Value="true" />
-                                                        <Condition Binding="{Binding IsWhite}" Value="false"/>
+                                                        <Condition Binding="{Binding IsExternal}" Value="True" />
+                                                        <Condition Binding="{Binding IsWhite}" Value="False"/>
                                                     </MultiDataTrigger.Conditions>
                                                     <Setter Property="Foreground" Value="#FFFF2800"/>
                                                 </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsExternal}" Value="False" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </MultiDataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsWhite}" Value="True"/>
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </MultiDataTrigger>
                                             </Style.Triggers>
                                             <Setter Property="ToolTip" Value="{Binding MailAddress, Mode=OneWay}" />
+                                            <Setter Property="IsTabStop" Value="False"/>
                                         </Style>
                                     </DataGridTextColumn.CellStyle>
                                 </DataGridTextColumn>
                             </DataGrid.Columns>
+                            <DataGrid.Resources>
+                                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Transparent" />
+                                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent" />
+                            </DataGrid.Resources>
                         </DataGrid>
                     </StackPanel>
                 </GroupBox>
@@ -147,31 +226,54 @@
                                         <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
+                                <DataGridTemplateColumn.CellStyle>
+                                    <Style TargetType="DataGridCell">
+                                        <Setter Property="IsTabStop" Value="False"/>
+                                    </Style>
+                                </DataGridTemplateColumn.CellStyle>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Binding="{Binding FileName, Mode=OneWay}" Width="Auto" IsReadOnly="True" />
-                            <DataGridTextColumn Binding="{Binding FileType, Mode=OneWay}" Width="Auto" IsReadOnly="True" >
+                            <DataGridTextColumn Binding="{Binding FileName, Mode=OneWay}" Width="Auto" IsReadOnly="True" Foreground="Black" >
                                 <DataGridTextColumn.CellStyle>
                                     <Style TargetType="DataGridCell">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsDangerous}" Value="true">
-                                                <Setter Property="Foreground" Value="#FFFF2800"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
+                                        <Setter Property="IsTabStop" Value="False"/>
                                     </Style>
                                 </DataGridTextColumn.CellStyle>
                             </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding FileSize, Mode=OneWay}" Width="Auto" IsReadOnly="True" >
+                            <DataGridTextColumn Binding="{Binding FileType, Mode=OneWay}" Width="Auto" IsReadOnly="True">
                                 <DataGridTextColumn.CellStyle>
                                     <Style TargetType="DataGridCell">
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsTooBig}" Value="true">
+                                            <DataTrigger Binding="{Binding IsDangerous}" Value="True">
                                                 <Setter Property="Foreground" Value="#FFFF2800"/>
                                             </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsDangerous}" Value="False">
+                                                <Setter Property="Foreground" Value="Black"/>
+                                            </DataTrigger>
                                         </Style.Triggers>
+                                        <Setter Property="IsTabStop" Value="False"/>
+                                    </Style>
+                                </DataGridTextColumn.CellStyle>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding FileSize, Mode=OneWay}" Width="Auto" IsReadOnly="True">
+                                <DataGridTextColumn.CellStyle>
+                                    <Style TargetType="DataGridCell">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsTooBig}" Value="True">
+                                                <Setter Property="Foreground" Value="#FFFF2800"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsTooBig}" Value="False">
+                                                <Setter Property="Foreground" Value="Black"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                        <Setter Property="IsTabStop" Value="False"/>
                                     </Style>
                                 </DataGridTextColumn.CellStyle>
                             </DataGridTextColumn>
                         </DataGrid.Columns>
+                        <DataGrid.Resources>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Transparent" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent" />
+                        </DataGrid.Resources>
                     </DataGrid>
                 </GroupBox>
                 <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailInfo, Mode=OneWay}" FontSize="11" Padding="3,3,3,3" Margin="0,1.5,0,0">

--- a/OutlookOkan/Views/ConfirmationWindow.xaml
+++ b/OutlookOkan/Views/ConfirmationWindow.xaml
@@ -11,8 +11,8 @@
         ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" Height="590" Width="780">
     <StackPanel Margin="5,8">
         <StackPanel Margin="5,0,0,0">
-            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ConfirmationMessage1, Mode=OneWay}" FontSize="12" Padding="0"/>
-            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ConfirmationMessage2, Mode=OneWay}" FontSize="10" Padding="0" Margin="0,3"/>
+            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ConfirmationMessage1, Mode=OneWay}" FontSize="12" Padding="0" />
+            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ConfirmationMessage2, Mode=OneWay}" FontSize="10" Padding="0" Margin="0,3" />
         </StackPanel>
         <StackPanel  Margin="8,6,8,8">
             <GroupBox Header="{Binding AlertCount}" FontSize="11" Padding="3,3,3,3">
@@ -21,25 +21,25 @@
                         <DataGridTemplateColumn IsReadOnly="True">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
+                                    <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked" />
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                             <DataGridTemplateColumn.CellStyle>
                                 <Style TargetType="DataGridCell">
-                                    <Setter Property="IsTabStop" Value="False"/>
+                                    <Setter Property="IsTabStop" Value="False" />
                                 </Style>
                             </DataGridTemplateColumn.CellStyle>
                         </DataGridTemplateColumn>
                         <DataGridTextColumn Binding="{Binding AlertMessage, Mode=OneWay}" Width="*" IsReadOnly="True">
                             <DataGridTextColumn.CellStyle>
                                 <Style TargetType="DataGridCell">
-                                    <Setter Property="IsTabStop" Value="False"/>
+                                    <Setter Property="IsTabStop" Value="False" />
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding IsImportant}" Value="True">
-                                            <Setter Property="Foreground" Value="#FFFF2800"/>
+                                            <Setter Property="Foreground" Value="#FFFF2800" />
                                         </DataTrigger>
                                         <DataTrigger Binding="{Binding IsImportant}" Value="False">
-                                            <Setter Property="Foreground" Value="Black"/>
+                                            <Setter Property="Foreground" Value="Black" />
                                         </DataTrigger>
                                     </Style.Triggers>
                                 </Style>
@@ -62,18 +62,18 @@
             <StackPanel Grid.Column="0" Margin="8,2,8,8">
                 <GroupBox Header="{Binding AddressCount}" FontSize="11" Padding="3,3,3,3" >
                     <StackPanel>
-                        <Label Content="{Binding ToAddressCount}" Margin="0,5,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11"/>
+                        <Label Content="{Binding ToAddressCount}" Margin="0,5,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11" />
                         <DataGrid Height="70" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding ToAddresses,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" >
                             <DataGrid.Columns>
                                 <DataGridTemplateColumn IsReadOnly="True">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center"  Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
+                                            <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center"  Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked" />
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                     <DataGridTemplateColumn.CellStyle>
                                         <Style TargetType="DataGridCell">
-                                            <Setter Property="IsTabStop" Value="False"/>
+                                            <Setter Property="IsTabStop" Value="False" />
                                         </Style>
                                     </DataGridTemplateColumn.CellStyle>
                                 </DataGridTemplateColumn>
@@ -92,17 +92,17 @@
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding IsExternal}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="Black"/>
+                                                    <Setter Property="Foreground" Value="Black" />
                                                 </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding IsWhite}" Value="True"/>
+                                                        <Condition Binding="{Binding IsWhite}" Value="True" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="Black"/>
+                                                    <Setter Property="Foreground" Value="Black" />
                                                 </MultiDataTrigger>
                                             </Style.Triggers>
                                             <Setter Property="ToolTip" Value="{Binding MailAddress, Mode=OneWay}" />
-                                            <Setter Property="IsTabStop" Value="False"/>
+                                            <Setter Property="IsTabStop" Value="False" />
                                         </Style>
                                     </DataGridTextColumn.CellStyle>
                                 </DataGridTextColumn>
@@ -112,18 +112,18 @@
                                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent" />
                             </DataGrid.Resources>
                         </DataGrid>
-                        <Label Content="{Binding CcAddressCount}" Margin="0,6,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11"/>
+                        <Label Content="{Binding CcAddressCount}" Margin="0,6,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11" />
                         <DataGrid Height="70" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding CcAddresses,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" >
                             <DataGrid.Columns>
                                 <DataGridTemplateColumn IsReadOnly="True">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
+                                            <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked" />
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                     <DataGridTemplateColumn.CellStyle>
                                         <Style TargetType="DataGridCell">
-                                            <Setter Property="IsTabStop" Value="False"/>
+                                            <Setter Property="IsTabStop" Value="False" />
                                         </Style>
                                     </DataGridTemplateColumn.CellStyle>
                                 </DataGridTemplateColumn>
@@ -136,23 +136,23 @@
                                                         <Condition Binding="{Binding IsExternal}" Value="True" />
                                                         <Condition Binding="{Binding IsWhite}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="#FFFF2800"/>
+                                                    <Setter Property="Foreground" Value="#FFFF2800" />
                                                 </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding IsExternal}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="Black"/>
+                                                    <Setter Property="Foreground" Value="Black" />
                                                 </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding IsWhite}" Value="True"/>
+                                                        <Condition Binding="{Binding IsWhite}" Value="True" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="Black"/>
+                                                    <Setter Property="Foreground" Value="Black" />
                                                 </MultiDataTrigger>
                                             </Style.Triggers>
                                             <Setter Property="ToolTip" Value="{Binding MailAddress, Mode=OneWay}" />
-                                            <Setter Property="IsTabStop" Value="False"/>
+                                            <Setter Property="IsTabStop" Value="False" />
                                         </Style>
                                     </DataGridTextColumn.CellStyle>
                                 </DataGridTextColumn>
@@ -162,18 +162,18 @@
                                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent" />
                             </DataGrid.Resources>
                         </DataGrid>
-                        <Label Content="{Binding BccAddressCount}" Margin="0,6,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11"/>
+                        <Label Content="{Binding BccAddressCount}" Margin="0,6,0,0" Padding="0" VerticalAlignment="Bottom" FontSize="11" />
                         <DataGrid Height="70" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding BccAddresses,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" >
                             <DataGrid.Columns>
                                 <DataGridTemplateColumn IsReadOnly="True">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
+                                            <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked" />
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                     <DataGridTemplateColumn.CellStyle>
                                         <Style TargetType="DataGridCell">
-                                            <Setter Property="IsTabStop" Value="False"/>
+                                            <Setter Property="IsTabStop" Value="False" />
                                         </Style>
                                     </DataGridTemplateColumn.CellStyle>
                                 </DataGridTemplateColumn>
@@ -184,25 +184,25 @@
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding IsExternal}" Value="True" />
-                                                        <Condition Binding="{Binding IsWhite}" Value="False"/>
+                                                        <Condition Binding="{Binding IsWhite}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="#FFFF2800"/>
+                                                    <Setter Property="Foreground" Value="#FFFF2800" />
                                                 </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding IsExternal}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="Black"/>
+                                                    <Setter Property="Foreground" Value="Black" />
                                                 </MultiDataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding IsWhite}" Value="True"/>
+                                                        <Condition Binding="{Binding IsWhite}" Value="True" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Foreground" Value="Black"/>
+                                                    <Setter Property="Foreground" Value="Black" />
                                                 </MultiDataTrigger>
                                             </Style.Triggers>
                                             <Setter Property="ToolTip" Value="{Binding MailAddress, Mode=OneWay}" />
-                                            <Setter Property="IsTabStop" Value="False"/>
+                                            <Setter Property="IsTabStop" Value="False" />
                                         </Style>
                                     </DataGridTextColumn.CellStyle>
                                 </DataGridTextColumn>
@@ -215,7 +215,7 @@
                     </StackPanel>
                 </GroupBox>
             </StackPanel>
-            <GridSplitter Grid.Column="1" IsTabStop="False"/>
+            <GridSplitter Grid.Column="1" IsTabStop="False" />
             <StackPanel Grid.Column="2" Margin="0,2,8,0">
                 <GroupBox Header="{Binding AttachmentCount}"  FontSize="11" Padding="3,3,3,3">
                     <DataGrid Height="68" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding Attachments,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" >
@@ -223,19 +223,19 @@
                             <DataGridTemplateColumn IsReadOnly="True">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked"/>
+                                        <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" VerticalAlignment="Center" Checked="ToggleButton_OnChecked" Unchecked="ToggleButton_OnUnchecked" />
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                                 <DataGridTemplateColumn.CellStyle>
                                     <Style TargetType="DataGridCell">
-                                        <Setter Property="IsTabStop" Value="False"/>
+                                        <Setter Property="IsTabStop" Value="False" />
                                     </Style>
                                 </DataGridTemplateColumn.CellStyle>
                             </DataGridTemplateColumn>
                             <DataGridTextColumn Binding="{Binding FileName, Mode=OneWay}" Width="Auto" IsReadOnly="True" Foreground="Black" >
                                 <DataGridTextColumn.CellStyle>
                                     <Style TargetType="DataGridCell">
-                                        <Setter Property="IsTabStop" Value="False"/>
+                                        <Setter Property="IsTabStop" Value="False" />
                                     </Style>
                                 </DataGridTextColumn.CellStyle>
                             </DataGridTextColumn>
@@ -244,13 +244,13 @@
                                     <Style TargetType="DataGridCell">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsDangerous}" Value="True">
-                                                <Setter Property="Foreground" Value="#FFFF2800"/>
+                                                <Setter Property="Foreground" Value="#FFFF2800" />
                                             </DataTrigger>
                                             <DataTrigger Binding="{Binding IsDangerous}" Value="False">
-                                                <Setter Property="Foreground" Value="Black"/>
+                                                <Setter Property="Foreground" Value="Black" />
                                             </DataTrigger>
                                         </Style.Triggers>
-                                        <Setter Property="IsTabStop" Value="False"/>
+                                        <Setter Property="IsTabStop" Value="False" />
                                     </Style>
                                 </DataGridTextColumn.CellStyle>
                             </DataGridTextColumn>
@@ -259,13 +259,13 @@
                                     <Style TargetType="DataGridCell">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsTooBig}" Value="True">
-                                                <Setter Property="Foreground" Value="#FFFF2800"/>
+                                                <Setter Property="Foreground" Value="#FFFF2800" />
                                             </DataTrigger>
                                             <DataTrigger Binding="{Binding IsTooBig}" Value="False">
-                                                <Setter Property="Foreground" Value="Black"/>
+                                                <Setter Property="Foreground" Value="Black" />
                                             </DataTrigger>
                                         </Style.Triggers>
-                                        <Setter Property="IsTabStop" Value="False"/>
+                                        <Setter Property="IsTabStop" Value="False" />
                                     </Style>
                                 </DataGridTextColumn.CellStyle>
                             </DataGridTextColumn>
@@ -279,33 +279,33 @@
                 <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailInfo, Mode=OneWay}" FontSize="11" Padding="3,3,3,3" Margin="0,1.5,0,0">
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Sender, Mode=OneWay}" FontSize="11" Padding="0" Width="42"/>
-                            <TextBox Width="304" Padding="0" Margin="5,0,0,0" IsReadOnly="True" Text="{Binding Sender, Mode=OneWay}"/>
+                            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Sender, Mode=OneWay}" FontSize="11" Padding="0" Width="42" />
+                            <TextBox Width="304" Padding="0" Margin="5,0,0,0" IsReadOnly="True" Text="{Binding Sender, Mode=OneWay}" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
-                            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Subject, Mode=OneWay}" FontSize="11" Padding="0" Width="42"/>
-                            <TextBox Width="304" Padding="0" Margin="5,0,0,0" IsReadOnly="True" Text="{Binding Subject, Mode=OneWay}"/>
+                            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Subject, Mode=OneWay}" FontSize="11" Padding="0" Width="42" />
+                            <TextBox Width="304" Padding="0" Margin="5,0,0,0" IsReadOnly="True" Text="{Binding Subject, Mode=OneWay}" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
                             <StackPanel Orientation="Horizontal">
-                                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailType, Mode=OneWay}" FontSize="11" Padding="0" Width="42"/>
-                                <TextBox Width="108" Padding="0" Margin="5,0,0,0" IsReadOnly="True" Text="{Binding MailType, Mode=OneWay}"/>
+                                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailType, Mode=OneWay}" FontSize="11" Padding="0" Width="42" />
+                                <TextBox Width="108" Padding="0" Margin="5,0,0,0" IsReadOnly="True" Text="{Binding MailType, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">
-                                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.DeferredDeliveryMinutes, Mode=OneWay}" FontSize="11" Padding="0" Width="148" Margin="11,0,0,0"/>
-                                <TextBox x:Name="DeferredDeliveryMinutesBox" Width="32" Padding="0" Margin="5,0,0,0" IsReadOnly="false" TextAlignment="Right" Text="{Binding DeferredDeliveryMinutes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" PreviewTextInput="DeferredDeliveryMinutesBox_OnPreviewTextInput" CommandManager.PreviewExecuted="DeferredDeliveryMinutesBox_OnPreviewExecuted" InputMethod.IsInputMethodEnabled="False" InputMethod.PreferredImeState="Off"/>
+                                <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.DeferredDeliveryMinutes, Mode=OneWay}" FontSize="11" Padding="0" Width="148" Margin="11,0,0,0" />
+                                <TextBox x:Name="DeferredDeliveryMinutesBox" Width="32" Padding="0" Margin="5,0,0,0" IsReadOnly="false" TextAlignment="Right" Text="{Binding DeferredDeliveryMinutes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" PreviewTextInput="DeferredDeliveryMinutesBox_OnPreviewTextInput" CommandManager.PreviewExecuted="DeferredDeliveryMinutesBox_OnPreviewExecuted" InputMethod.IsInputMethodEnabled="False" />
                             </StackPanel>
                         </StackPanel>
                     </StackPanel>
                 </GroupBox>
                 <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailBody, Mode=OneWay}" FontSize="11" Padding="3,3,3,3" Margin="0,1.5,0,0">
-                    <TextBox Height="63" VerticalScrollBarVisibility="Visible" IsReadOnly="True" Text="{Binding MailBody, Mode=OneWay}"/>
+                    <TextBox Height="63" VerticalScrollBarVisibility="Visible" IsReadOnly="True" Text="{Binding MailBody, Mode=OneWay}" />
                 </GroupBox>
             </StackPanel>
         </Grid>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,8,0">
-            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Send, Mode=OneWay}" Width="48" Margin="0,0,10,0" IsEnabled="{Binding IsCanSendMail}" Click="SendButton_OnClick"/>
-            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Cancel, Mode=OneWay}" Width="100" Margin="3,0,0,0" IsDefault="True" IsCancel="True" Click="CancelButton_OnClick"/>
+            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Send, Mode=OneWay}" Width="48" Margin="0,0,10,0" IsEnabled="{Binding IsCanSendMail}" Click="SendButton_OnClick" />
+            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Cancel, Mode=OneWay}" Width="100" Margin="3,0,0,0" IsDefault="True" IsCancel="True" Click="CancelButton_OnClick" />
         </StackPanel>
     </StackPanel>
 </Window>

--- a/OutlookOkan/Views/SettingsWindow.xaml
+++ b/OutlookOkan/Views/SettingsWindow.xaml
@@ -16,7 +16,7 @@
                     <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.General, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
                         <StackPanel Orientation="Vertical">
                             <StackPanel Orientation="Horizontal">
-                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding EnableForgottenToAttachAlert, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding EnableForgottenToAttachAlert, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.EnableForgottenToAttachAlert, Mode=OneWay}" />
                             </StackPanel>
                         </StackPanel>
@@ -24,15 +24,15 @@
                     <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.DontShowConfirmationScreen, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3"  Margin="0,5,0,0">
                         <StackPanel Orientation="Vertical">
                             <StackPanel Orientation="Horizontal">
-                                <CheckBox Margin="0,0,8,0"  IsChecked="{Binding IsDoNotConfirmationIfAllRecipientsAreSameDomain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <CheckBox Margin="0,0,8,0"  IsChecked="{Binding IsDoNotConfirmationIfAllRecipientsAreSameDomain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.IfAllSameDomain, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding IsDoDoNotConfirmationIfAllWhite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding IsDoDoNotConfirmationIfAllWhite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.IfAllWhite, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding IsShowConfirmationToMultipleDomain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding IsShowConfirmationToMultipleDomain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.IsShowConfirmationToMultipleDomain, Mode=OneWay}" />
                             </StackPanel>
                         </StackPanel>
@@ -40,7 +40,7 @@
                     <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoCheckConfig, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3" Margin="0,5,0,0">
                         <StackPanel Orientation="Vertical">
                             <StackPanel Orientation="Horizontal">
-                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding IsAutoCheckIfAllRecipientsAreSameDomain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding IsAutoCheckIfAllRecipientsAreSameDomain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoCheckSameDomain, Mode=OneWay}" />
                             </StackPanel>
                         </StackPanel>
@@ -48,21 +48,21 @@
                     <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.GetMembersOfTheList, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3"  Margin="0,5,0,0">
                         <StackPanel Orientation="Vertical">
                             <StackPanel Orientation="Horizontal">
-                                <CheckBox Margin="0,0,8,0"  IsChecked="{Binding EnableGetExchangeDistributionListMembers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <CheckBox Margin="0,0,8,0"  IsChecked="{Binding EnableGetExchangeDistributionListMembers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.GetMembersOfTheExDistList, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="10,3,0,0">
-                                <TextBlock Text="=> "/>
-                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding ExchangeDistributionListMembersAreWhite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <TextBlock Text="=> " />
+                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding ExchangeDistributionListMembersAreWhite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoCheckMembersAddress, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding EnableGetContactGroupMembers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding EnableGetContactGroupMembers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.GetMembersOfTheContactGroup, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="10,3,0,0">
-                                <TextBlock Text="=> "/>
-                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding ContactGroupMembersAreWhite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <TextBlock Text="=> " />
+                                <CheckBox Margin="0,0,8,0" IsChecked="{Binding ContactGroupMembersAreWhite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoCheckMembersAddress, Mode=OneWay}" />
                             </StackPanel>
                         </StackPanel>
@@ -70,7 +70,7 @@
                     <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ChangeLanguage, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3" Margin="0,5,0,0">
                         <StackPanel Orientation="Vertical">
                             <ComboBox ItemsSource="{Binding Languages}" SelectedItem="{Binding Language, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" SelectedIndex="{Binding LanguageNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="LanguageName" />
-                            <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ChangeRibbonLanguageInfo, Mode=OneWay}" Margin="5,4,0,0"/>
+                            <TextBlock Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ChangeRibbonLanguageInfo, Mode=OneWay}" Margin="5,4,0,0" />
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
@@ -78,15 +78,15 @@
             <TabItem Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.WhiteList, Mode=OneWay}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="8,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Settings, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
                             <DataGrid Height="353" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Visible" BorderBrush="#FFD5DFE5" HeadersVisibility="All" RowHeaderWidth="15" ItemsSource="{Binding Whitelist, Mode=TwoWay}" AutoGenerateColumns="false" CanUserResizeColumns="True" CanUserSortColumns="True" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5" CellEditEnding="DataGrid_WhiteList_OnCellEditEnding">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailddressAndDomain, Mode=OneWay}" Binding="{Binding WhiteName, Mode=TwoWay}" Width="*">
+                                    <DataGridTextColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailddressAndDomain, Mode=OneWay}" Binding="{Binding WhiteName, Mode=TwoWay}" Width="*" >
                                         <DataGridTextColumn.ElementStyle>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailddressAndDomain, Mode=OneWay}" />
@@ -96,9 +96,9 @@
                                     <DataGridCheckBoxColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.IsSkipConfirmation, Mode=OneWay}" Binding="{Binding IsSkipConfirmation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="Auto">
                                         <DataGridCheckBoxColumn.ElementStyle>
                                             <Style TargetType="CheckBox">
-                                                <Setter Property="ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.IsSkipConfirmationInfo, Mode=OneWay}"/>
-                                                <Setter Property="VerticalAlignment" Value="Center"/>
-                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Setter Property="ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.IsSkipConfirmationInfo, Mode=OneWay}" />
+                                                <Setter Property="VerticalAlignment" Value="Center" />
+                                                <Setter Property="HorizontalAlignment" Value="Center" />
                                             </Style>
                                         </DataGridCheckBoxColumn.ElementStyle>
                                     </DataGridCheckBoxColumn>
@@ -106,15 +106,15 @@
                             </DataGrid>
                         </GroupBox>
                     </StackPanel>
-                    <GridSplitter Grid.Column="1"/>
+                    <GridSplitter Grid.Column="1" />
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleWhiteList, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
+                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleWhiteList, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True" />
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportWhiteList}"/>
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportWhiteList}"/>
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportWhiteList}" />
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportWhiteList}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -123,9 +123,9 @@
             <TabItem Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.NameAndDomain, Mode=OneWay}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="8,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Settings, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
@@ -149,15 +149,15 @@
                             </DataGrid>
                         </GroupBox>
                     </StackPanel>
-                    <GridSplitter Grid.Column="1"/>
+                    <GridSplitter Grid.Column="1" />
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleNameAndDomain, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
+                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleNameAndDomain, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True" />
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportNameAndDomainsList}"/>
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportNameAndDomainsList}"/>
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportNameAndDomainsList}" />
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportNameAndDomainsList}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -166,9 +166,9 @@
             <TabItem Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AlertKeyword, Mode=OneWay}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="8,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Settings, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
@@ -191,9 +191,9 @@
                                     <DataGridCheckBoxColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SendingForbid, Mode=OneWay}" Binding="{Binding IsCanNotSend, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="Auto">
                                         <DataGridCheckBoxColumn.ElementStyle>
                                             <Style TargetType="CheckBox">
-                                                <Setter Property="ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SendingForbidInfo, Mode=OneWay}"/>
-                                                <Setter Property="VerticalAlignment" Value="Center"/>
-                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Setter Property="ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SendingForbidInfo, Mode=OneWay}" />
+                                                <Setter Property="VerticalAlignment" Value="Center" />
+                                                <Setter Property="HorizontalAlignment" Value="Center" />
                                             </Style>
                                         </DataGridCheckBoxColumn.ElementStyle>
                                     </DataGridCheckBoxColumn>
@@ -201,15 +201,15 @@
                             </DataGrid>
                         </GroupBox>
                     </StackPanel>
-                    <GridSplitter Grid.Column="1"/>
+                    <GridSplitter Grid.Column="1" />
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertKeyword, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
+                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertKeyword, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True" />
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAlertKeywordAndMessagesList}"/>
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAlertKeywordAndMessagesList}"/>
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAlertKeywordAndMessagesList}" />
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAlertKeywordAndMessagesList}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -218,9 +218,9 @@
             <TabItem Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AlertMailAddress, Mode=OneWay}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="8,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Settings, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
@@ -236,9 +236,9 @@
                                     <DataGridCheckBoxColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SendingForbid, Mode=OneWay}" Binding="{Binding IsCanNotSend, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="Auto">
                                         <DataGridCheckBoxColumn.ElementStyle>
                                             <Style TargetType="CheckBox">
-                                                <Setter Property="ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SendingForbidInfo, Mode=OneWay}"/>
-                                                <Setter Property="VerticalAlignment" Value="Center"/>
-                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Setter Property="ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SendingForbidInfo, Mode=OneWay}" />
+                                                <Setter Property="VerticalAlignment" Value="Center" />
+                                                <Setter Property="HorizontalAlignment" Value="Center" />
                                             </Style>
                                         </DataGridCheckBoxColumn.ElementStyle>
                                     </DataGridCheckBoxColumn>
@@ -246,15 +246,15 @@
                             </DataGrid>
                         </GroupBox>
                     </StackPanel>
-                    <GridSplitter Grid.Column="1"/>
+                    <GridSplitter Grid.Column="1" />
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertMailAddress, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
+                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAlertMailAddress, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True" />
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAlertAddressesList}"/>
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAlertAddressesList}"/>
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAlertAddressesList}" />
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAlertAddressesList}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -263,9 +263,9 @@
             <TabItem Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoAddCCorBCCByKeyword, Mode=OneWay}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="8,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Settings, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
@@ -282,7 +282,7 @@
                                         <DataGridTextColumn.ElementStyle>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CCorBCC, Mode=OneWay}" />
-                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Setter Property="HorizontalAlignment" Value="Center" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
                                     </DataGridTextColumn>
@@ -297,15 +297,15 @@
                             </DataGrid>
                         </GroupBox>
                     </StackPanel>
-                    <GridSplitter Grid.Column="1"/>
+                    <GridSplitter Grid.Column="1" />
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByKeyword, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
+                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByKeyword, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True" />
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAutoCcBccKeywordsList}"/>
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAutoCcBccKeywordsList}"/>
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAutoCcBccKeywordsList}" />
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAutoCcBccKeywordsList}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -314,9 +314,9 @@
             <TabItem Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoAddCCorBCCByMailAddressOrDomain, Mode=OneWay}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="8,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Settings, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
@@ -333,7 +333,7 @@
                                         <DataGridTextColumn.ElementStyle>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.InputCCorBCC, Mode=OneWay}" />
-                                                <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                <Setter Property="HorizontalAlignment" Value="Center" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
                                     </DataGridTextColumn>
@@ -348,15 +348,15 @@
                             </DataGrid>
                         </GroupBox>
                     </StackPanel>
-                    <GridSplitter Grid.Column="1"/>
+                    <GridSplitter Grid.Column="1" />
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByMailAddressOrDomain, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
+                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleAutoAddCCorBCCByMailAddressOrDomain, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True" />
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAutoCcBccRecipientsList}"/>
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAutoCcBccRecipientsList}"/>
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportAutoCcBccRecipientsList}" />
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportAutoCcBccRecipientsList}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -365,9 +365,9 @@
             <TabItem Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.DeferredDelivery, Mode=OneWay}">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="3*" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Margin="8,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Settings, Mode=OneWay}"  FontSize="11" Padding="3,3,3,3">
@@ -384,7 +384,7 @@
                                         <DataGridTextColumn.ElementStyle>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.InputDeferredDeliveryTime, Mode=OneWay}" />
-                                                <Setter Property="HorizontalAlignment" Value="Right"/>
+                                                <Setter Property="HorizontalAlignment" Value="Right" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
                                     </DataGridTextColumn>
@@ -392,15 +392,15 @@
                             </DataGrid>
                         </GroupBox>
                     </StackPanel>
-                    <GridSplitter Grid.Column="1"/>
+                    <GridSplitter Grid.Column="1" />
                     <StackPanel Grid.Column="2" Margin="1,2,8,8">
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExample, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
-                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleDeferredDelivery, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True"/>
+                            <TextBox Height="272" BorderBrush="White" FontSize="10" TextWrapping="Wrap" Text="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SettingExampleDeferredDelivery, Mode=OneWay}" Padding="0,12,0,0" IsReadOnly="True" />
                         </GroupBox>
                         <GroupBox Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ImportAndExport, Mode=OneWay}" FontSize="11" Padding="3,3,3,3">
                             <StackPanel Margin="4">
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportDeferredDeliveryMinutesesList}"/>
-                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportDeferredDeliveryMinutesesList}"/>
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVImport, Mode=OneWay}" Width="120" Padding="0" Margin="0,1,0,3" Command="{Binding ImportDeferredDeliveryMinutesesList}" />
+                                <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CSVExport, Mode=OneWay}" Width="120" Padding="0" Margin="0,8,0,0" Command="{Binding ExportDeferredDeliveryMinutesesList}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
@@ -408,12 +408,12 @@
             </TabItem>
         </TabControl>
         <StackPanel Margin="0,1,0,0">
-            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.HowToDaleteRow, Mode=OneWay}" Padding="0" Foreground="LightSlateGray"/>
+            <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.HowToDaleteRow, Mode=OneWay}" Padding="0" Foreground="LightSlateGray" />
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,1,0">
-            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.OK, Mode=OneWay}" Width="68" Click="OkButton_OnClick"/>
-            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Cancel, Mode=OneWay}" Width="68" Margin="10,0,0,0" IsCancel="True" Click="CancelButton_OnClick"/>
-            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Apply, Mode=OneWay}" Width="68" Margin="10,0,0,0" Click="ApplyButton_OnClick"/>
+            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.OK, Mode=OneWay}" Width="68" Click="OkButton_OnClick" />
+            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Cancel, Mode=OneWay}" Width="68" Margin="10,0,0,0" IsCancel="True" Click="CancelButton_OnClick" />
+            <Button Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.Apply, Mode=OneWay}" Width="68" Margin="10,0,0,0" Click="ApplyButton_OnClick" />
         </StackPanel>
     </StackPanel>
 </Window>

--- a/OutlookOkan/Views/SettingsWindow.xaml
+++ b/OutlookOkan/Views/SettingsWindow.xaml
@@ -92,6 +92,11 @@
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailddressAndDomain, Mode=OneWay}" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                     <DataGridCheckBoxColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.IsSkipConfirmation, Mode=OneWay}" Binding="{Binding IsSkipConfirmation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="Auto">
                                         <DataGridCheckBoxColumn.ElementStyle>
@@ -144,6 +149,11 @@
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.InputDomainInfo, Mode=OneWay}" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
@@ -232,6 +242,11 @@
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.MailddressAndDomain, Mode=OneWay}" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                     <DataGridCheckBoxColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.SendingForbid, Mode=OneWay}" Binding="{Binding IsCanNotSend, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="Auto">
                                         <DataGridCheckBoxColumn.ElementStyle>
@@ -285,6 +300,11 @@
                                                 <Setter Property="HorizontalAlignment" Value="Center" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoAddMailAddress, Mode=OneWay}" Binding="{Binding AutoAddAddress, Mode=TwoWay}" Width="*">
                                         <DataGridTextColumn.ElementStyle>
@@ -292,6 +312,11 @@
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoAddMailAddress, Mode=OneWay}" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
@@ -328,6 +353,11 @@
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoAddCCorBCCByMailAddressOrDomainInfo, Mode=OneWay}" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.CCorBCC, Mode=OneWay}" Binding="{Binding CcOrBcc, Mode=TwoWay}" Width="Auto">
                                         <DataGridTextColumn.ElementStyle>
@@ -336,6 +366,11 @@
                                                 <Setter Property="HorizontalAlignment" Value="Center" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoAddMailAddress, Mode=OneWay}" Binding="{Binding AutoAddAddress, Mode=TwoWay}" Width="*">
                                         <DataGridTextColumn.ElementStyle>
@@ -343,6 +378,11 @@
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.AutoAddMailAddress, Mode=OneWay}" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
@@ -379,6 +419,11 @@
                                                 <Setter Property="ToolTipService.ToolTip" Value="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.DeferredDeliveryEmailAddressOrDomainInfo, Mode=OneWay}" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                     <DataGridTextColumn Header="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.DeferredDeliveryTime, Mode=OneWay}" Binding="{Binding DeferredMinutes, Mode=TwoWay}" Width="Auto">
                                         <DataGridTextColumn.ElementStyle>
@@ -387,6 +432,11 @@
                                                 <Setter Property="HorizontalAlignment" Value="Right" />
                                             </Style>
                                         </DataGridTextColumn.ElementStyle>
+                                        <DataGridTextColumn.EditingElementStyle>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="InputMethod.IsInputMethodEnabled" Value="False" />
+                                            </Style>
+                                        </DataGridTextColumn.EditingElementStyle>
                                     </DataGridTextColumn>
                                 </DataGrid.Columns>
                             </DataGrid>


### PR DESCRIPTION
#### 変更点と改善点
- [確認画面] 選択行の背景色を変更しないよう変更  
→ 赤い文字に青い背景だと見づらいため、見やすさを改善
- [確認画面] チェックボックスをタブキーで移動できるよう変更  
→ タブキー、スペース、タブキー、スペース の繰り返しで、簡単にチェックできるよう改善
- [設定画面] 日本語を入力する必要のない設定欄には、英字しか入力できないよう変更
→ 入力ミスを防いだり、IMEをオンオフする手間をなくせるよう改善

#### その他
- ソースコードの一部の書式を統一