### PR TITLE
.msgファイルを2回目に開けない問題(リソースの開放漏れ)を修正 / 社外アドレスが含まれる配布リストのメンバー展開時の表示を改善

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2020 Noraneko Inc.
+   Copyright 2021 Noraneko Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/OutlookOkan/Models/GenerateCheckList.cs
+++ b/OutlookOkan/Models/GenerateCheckList.cs
@@ -512,15 +512,20 @@ namespace OutlookOkan.Models
                             }
                             catch (COMException e)
                             {
-                                if (e.ErrorCode == -2147467260)
+                                switch (e.ErrorCode)
                                 {
-                                    //HRESULT:0x80004004 対策
-                                    Thread.Sleep(10);
-                                    errorCount++;
-                                }
-                                else
-                                {
-                                    isDone = true;
+                                    case -2147467260:
+                                        //HRESULT:0x80004004 対策
+                                        Thread.Sleep(10);
+                                        errorCount++;
+                                        break;
+                                    case -2147467259:
+                                        mailAddress = Resources.ExternalRecipient;
+                                        isDone = true;
+                                        break;
+                                    default:
+                                        isDone = true;
+                                        break;
                                 }
                             }
                         }

--- a/OutlookOkan/OutlookOkan.csproj
+++ b/OutlookOkan/OutlookOkan.csproj
@@ -131,8 +131,8 @@
     <Reference Include="CsvHelper, Version=9.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.9.2.3\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.2.0.246, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.1.2.0\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.1.9, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.1.3.1\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Word, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/OutlookOkan/OutlookOkan.csproj
+++ b/OutlookOkan/OutlookOkan.csproj
@@ -35,7 +35,7 @@
     <PublishUrl>publish\</PublishUrl>
     <InstallUrl />
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>2.5.4.1</ApplicationVersion>
+    <ApplicationVersion>2.5.4.2</ApplicationVersion>
     <AutoIncrementApplicationRevision>false</AutoIncrementApplicationRevision>
     <UpdateEnabled>false</UpdateEnabled>
     <UpdateInterval>0</UpdateInterval>

--- a/OutlookOkan/Properties/AssemblyInfo.cs
+++ b/OutlookOkan/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Noraneko Inc.")]
 [assembly: AssemblyProduct("OutlookOkan")]
-[assembly: AssemblyCopyright("Copyright © Noraneko Inc. 2020")]
+[assembly: AssemblyCopyright("Copyright © Noraneko Inc. 2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.4.1")]
-[assembly: AssemblyFileVersion("2.5.4.1")]
+[assembly: AssemblyVersion("2.5.4.2")]
+[assembly: AssemblyFileVersion("2.5.4.2")]
 [assembly: NeutralResourcesLanguage("en-US")]
 

--- a/OutlookOkan/Properties/Resources.Designer.cs
+++ b/OutlookOkan/Properties/Resources.Designer.cs
@@ -390,7 +390,7 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copyright (C) 2020 Noraneko Inc..
+        ///   Looks up a localized string similar to Copyright (C) 2021 Noraneko Inc..
         /// </summary>
         public static string Copyright {
             get {
@@ -1348,7 +1348,7 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version 2.5.4.1.
+        ///   Looks up a localized string similar to Version 2.5.4.2.
         /// </summary>
         public static string Version {
             get {

--- a/OutlookOkan/Properties/Resources.Designer.cs
+++ b/OutlookOkan/Properties/Resources.Designer.cs
@@ -552,6 +552,15 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to External recipient.
+        /// </summary>
+        public static string ExternalRecipient {
+            get {
+                return ResourceManager.GetString("ExternalRecipient", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to get the information..
         /// </summary>
         public static string FailedToGetInformation {

--- a/OutlookOkan/Properties/Resources.ja-JP.resx
+++ b/OutlookOkan/Properties/Resources.ja-JP.resx
@@ -598,4 +598,7 @@
   <data name="SettingExampleAttachments" xml:space="preserve">
     <value>暗号化ZIPファイル(パスワード付きZIPファイル)が添付されている場合に、警告を表示したり、メールの送信を禁止できます。</value>
   </data>
+  <data name="ExternalRecipient" xml:space="preserve">
+    <value>社外アドレス</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.ja-JP.resx
+++ b/OutlookOkan/Properties/Resources.ja-JP.resx
@@ -358,10 +358,10 @@
     <value>株式会社のらねこ</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright (C) 2020 Noraneko Inc.</value>
+    <value>Copyright (C) 2021 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>バージョン 2.5.4.1</value>
+    <value>バージョン 2.5.4.2</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>バージョン情報</value>

--- a/OutlookOkan/Properties/Resources.resx
+++ b/OutlookOkan/Properties/Resources.resx
@@ -600,4 +600,7 @@ this feature will be applied.</value>
   <data name="SettingExampleAttachments" xml:space="preserve">
     <value>If an email has an encrypted ZIP file attached to it, you can display a warning or prohibit the sending of that email.</value>
   </data>
+  <data name="ExternalRecipient" xml:space="preserve">
+    <value>External recipient</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.resx
+++ b/OutlookOkan/Properties/Resources.resx
@@ -358,10 +358,10 @@
     <value>Noraneko Inc.</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright (C) 2020 Noraneko Inc.</value>
+    <value>Copyright (C) 2021 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.5.4.1</value>
+    <value>Version 2.5.4.2</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>About</value>

--- a/OutlookOkan/ThisAddIn.cs
+++ b/OutlookOkan/ThisAddIn.cs
@@ -13,7 +13,7 @@ using Word = Microsoft.Office.Interop.Word;
 
 namespace OutlookOkan
 {
-    public partial class ThisAddIn 
+    public partial class ThisAddIn
     {
         private readonly GeneralSetting _generalSetting = new GeneralSetting();
         private Outlook.Inspectors _inspectors;
@@ -92,7 +92,7 @@ namespace OutlookOkan
                 {
                     ResourceService.Instance.ChangeCulture(_generalSetting.LanguageCode);
                 }
-                
+
                 var generateCheckList = new GenerateCheckList();
                 var checklist = generateCheckList.GenerateCheckListFromMail((Outlook._MailItem)item, _generalSetting);
 

--- a/OutlookOkan/packages.config
+++ b/OutlookOkan/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="9.2.3" targetFramework="net462" />
-  <package id="SharpZipLib" version="1.2.0" targetFramework="net462" />
+  <package id="SharpZipLib" version="1.3.1" targetFramework="net462" />
   <package id="Ude.NetStandard" version="1.2.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
## 機能追加

- なし

## 改善/変更

- なし

## 不具合修正

- .msgファイルを2回目に開けない問題(リソースの開放漏れ)を修正。
- 社外アドレスが含まれる配布リストのメンバーを展開して表示する際、社外アドレスに情報取得エラーと表示される問題を暫定対策。

## その他

- ライブラリのバージョンを更新