### PR TITLE
v2.8系の不具合修正

### DIFF
--- a/OutlookOkan/Handlers/OfficeFileHandler.cs
+++ b/OutlookOkan/Handlers/OfficeFileHandler.cs
@@ -47,15 +47,6 @@ namespace OutlookOkan.Handlers
                         //パスワード違いの例外となった場合、パスワード付きDOCXとして判定。
                         isEncrypted = e.HResult == -2146822880;
                     }
-
-                    Thread.Sleep(10);
-                    tempWordApp.Quit();
-                    Thread.Sleep(10);
-                    _ = Marshal.ReleaseComObject(tempWordApp);
-                    tempWordApp = null;
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                    GC.Collect();
                     break;
                 case "xls":
                 case "xlsx":
@@ -84,15 +75,6 @@ namespace OutlookOkan.Handlers
                         //パスワード違いの例外となった場合、パスワード付きXLSXとして判定。
                         isEncrypted = e.HResult == -2146827284;
                     }
-
-                    Thread.Sleep(10);
-                    tempExcelApp.Quit();
-                    Thread.Sleep(10);
-                    _ = Marshal.ReleaseComObject(tempExcelApp);
-                    tempExcelApp = null;
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                    GC.Collect();
                     break;
                 case "ppt":
                 case "pptx":
@@ -114,15 +96,6 @@ namespace OutlookOkan.Handlers
                         //パスワード違いの例外となった場合、パスワード付きPPTXとして判定。
                         isEncrypted = e.HResult == -2147467259;
                     }
-
-                    Thread.Sleep(10);
-                    tempPowerPointApp.Quit();
-                    Thread.Sleep(10);
-                    _ = Marshal.ReleaseComObject(tempPowerPointApp);
-                    tempPowerPointApp = null;
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                    GC.Collect();
                     break;
                 default:
                     return false;
@@ -171,11 +144,6 @@ namespace OutlookOkan.Handlers
                             _ = Marshal.ReleaseComObject(excelFile);
                             excelFile = null;
                         }
-                        Thread.Sleep(10);
-                        tempExcelApp.Quit();
-                        Thread.Sleep(10);
-                        _ = Marshal.ReleaseComObject(tempExcelApp);
-                        tempExcelApp = null;
                     }
                     catch (Exception)
                     {
@@ -212,12 +180,6 @@ namespace OutlookOkan.Handlers
                             _ = Marshal.ReleaseComObject(wordFile);
                             wordFile = null;
                         }
-
-                        Thread.Sleep(10);
-                        tempWordApp.Quit();
-                        Thread.Sleep(10);
-                        _ = Marshal.ReleaseComObject(tempWordApp);
-                        tempWordApp = null;
                     }
                     catch (Exception)
                     {
@@ -247,12 +209,6 @@ namespace OutlookOkan.Handlers
                             _ = Marshal.ReleaseComObject(pptFile);
                             pptFile = null;
                         }
-
-                        Thread.Sleep(10);
-                        tempPptApp.Quit();
-                        Thread.Sleep(10);
-                        _ = Marshal.ReleaseComObject(tempPptApp);
-                        tempPptApp = null;
                     }
                     catch (Exception)
                     {
@@ -261,8 +217,7 @@ namespace OutlookOkan.Handlers
                     break;
 
                 default:
-                    isHasVbProject = false;
-                    break;
+                    return false;
             }
 
             return isHasVbProject;

--- a/OutlookOkan/Handlers/OfficeFileHandler.cs
+++ b/OutlookOkan/Handlers/OfficeFileHandler.cs
@@ -64,6 +64,7 @@ namespace OutlookOkan.Handlers
                     {
                         var excelFile = tempExcelApp.Workbooks.Open(filePath, Password: null);
                         isEncrypted = false;
+
                         Thread.Sleep(10);
                         excelFile.Close(false);
                         Thread.Sleep(10);
@@ -150,7 +151,6 @@ namespace OutlookOkan.Handlers
                         //Do Nothing.
                     }
                     break;
-
                 case "doc":
                 case "docx":
                 case "docm":
@@ -186,7 +186,6 @@ namespace OutlookOkan.Handlers
                         //Do Nothing.
                     }
                     break;
-
                 case "ppt":
                 case "pptx":
                 case "pptm":
@@ -215,7 +214,6 @@ namespace OutlookOkan.Handlers
                         //Do Nothing.
                     }
                     break;
-
                 default:
                     return false;
             }

--- a/OutlookOkan/Models/GenerateCheckList.cs
+++ b/OutlookOkan/Models/GenerateCheckList.cs
@@ -1198,7 +1198,18 @@ namespace OutlookOkan.Models
                 var fileSize = "?KB";
                 if (((dynamic)item).Attachments[i + 1].Size != 0)
                 {
-                    fileSize = Math.Round(((double)((dynamic)item).Attachments[i + 1].Size / 1024), 0, MidpointRounding.AwayFromZero).ToString("##,###") + "KB";
+                    var sizeInKb = (double)((dynamic)item).Attachments[i + 1].Size / 1024;
+                    string formattedSize;
+                    if (sizeInKb >= 1 || sizeInKb == 0)
+                    {
+                        formattedSize = Math.Round(sizeInKb).ToString("##,###");
+                    }
+                    else
+                    {
+                        formattedSize = sizeInKb.ToString("0.###");
+                    }
+
+                    fileSize = formattedSize + "KB";
                 }
 
                 if (((dynamic)item).Attachments[i + 1].Size >= 10485760)

--- a/OutlookOkan/Models/GenerateCheckList.cs
+++ b/OutlookOkan/Models/GenerateCheckList.cs
@@ -310,8 +310,35 @@ namespace OutlookOkan.Models
             }
             catch (Exception)
             {
-                checkList.Sender = Resources.FailedToGetInformation;
-                checkList.SenderDomain = @"------------------";
+                try
+                {
+                    if (IsTaskRequestItem)
+                    {
+                        if (item is Outlook.TaskRequestItem taskRequest)
+                        {
+                            var associatedTask = taskRequest.GetAssociatedTask(false);
+
+                            if (associatedTask != null)
+                            {
+                                var senderAddress = associatedTask.SendUsingAccount?.SmtpAddress;
+                                checkList.Sender = senderAddress ?? Resources.FailedToGetInformation;
+
+                                Marshal.ReleaseComObject(associatedTask);
+                                checkList.SenderDomain = checkList.Sender == Resources.FailedToGetInformation ? "------------------" : checkList.Sender.Substring(checkList.Sender.IndexOf("@", StringComparison.Ordinal));
+                            }
+                        }
+                    }
+                    else
+                    {
+                        checkList.Sender = Resources.FailedToGetInformation;
+                        checkList.SenderDomain = @"------------------";
+                    }
+                }
+                catch (Exception)
+                {
+                    checkList.Sender = Resources.FailedToGetInformation;
+                    checkList.SenderDomain = @"------------------";
+                }
             }
 
             return checkList;

--- a/OutlookOkan/Models/GenerateCheckList.cs
+++ b/OutlookOkan/Models/GenerateCheckList.cs
@@ -215,7 +215,7 @@ namespace OutlookOkan.Models
                         Outlook.ExchangeUser exchangeUser = null;
 
                         var sender = ((Outlook.MailItem)item).Sender;
-                        
+
                         var errorCount = 0;
                         while (errorCount < 100)
                         {

--- a/OutlookOkan/OutlookOkan.csproj
+++ b/OutlookOkan/OutlookOkan.csproj
@@ -35,7 +35,7 @@
     <PublishUrl>publish\</PublishUrl>
     <InstallUrl />
     <TargetCulture>en</TargetCulture>
-    <ApplicationVersion>2.8.0.11</ApplicationVersion>
+    <ApplicationVersion>2.8.1.00</ApplicationVersion>
     <AutoIncrementApplicationRevision>false</AutoIncrementApplicationRevision>
     <UpdateEnabled>false</UpdateEnabled>
     <UpdateInterval>0</UpdateInterval>
@@ -357,6 +357,7 @@
   <ItemGroup>
     <Resource Include="Images\Noraneko_Logo.png" />
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/OutlookOkan/Properties/AssemblyInfo.cs
+++ b/OutlookOkan/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.0.12")]
-[assembly: AssemblyFileVersion("2.8.0.12")]
+[assembly: AssemblyVersion("2.8.1.00")]
+[assembly: AssemblyFileVersion("2.8.1.00")]
 [assembly: NeutralResourcesLanguage("en-US")]
 

--- a/OutlookOkan/Properties/Resources.Designer.cs
+++ b/OutlookOkan/Properties/Resources.Designer.cs
@@ -2324,7 +2324,7 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version 2.8.0.1.2.
+        ///   Looks up a localized string similar to Version 2.8.1.
         /// </summary>
         public static string Version {
             get {

--- a/OutlookOkan/Properties/Resources.Designer.cs
+++ b/OutlookOkan/Properties/Resources.Designer.cs
@@ -2121,9 +2121,7 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enabling this feature may cause problems.
-        ///
-        ///*Settings will be reflected after restarting Outlook..
+        ///   Looks up a localized string similar to Settings will be reflected after restarting Outlook..
         /// </summary>
         public static string SettingExampleSecurityForReceivedMail {
             get {

--- a/OutlookOkan/Properties/Resources.Designer.cs
+++ b/OutlookOkan/Properties/Resources.Designer.cs
@@ -1330,6 +1330,15 @@ namespace OutlookOkan.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Since there is no Internet connection, the safety check feature is not available when opening e-mail..
+        /// </summary>
+        public static string IsNoInternetCantUseSecurityForReceivedMail {
+            get {
+                return ResourceManager.GetString("IsNoInternetCantUseSecurityForReceivedMail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A file embedded in an HTML mail is not treated as an attachment..
         /// </summary>
         public static string IsNotTreatedAsAttachmentsAtHtmlEmbeddedFiles {

--- a/OutlookOkan/Properties/Resources.de-DE.resx
+++ b/OutlookOkan/Properties/Resources.de-DE.resx
@@ -896,9 +896,7 @@ wird diese Funktion angewendet.</value>
 *Die Einstellungen werden nach dem Neustart von Outlook übernommen.</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>Die Aktivierung dieser Funktion kann zu Problemen führen.
-
-*Die Einstellungen werden nach dem Neustart von Outlook übernommen.</value>
+    <value>Die Einstellungen werden nach dem Neustart von Outlook übernommen.</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>Verwenden Sie die Warnfunktion beim Öffnen von Anhängen.</value>

--- a/OutlookOkan/Properties/Resources.de-DE.resx
+++ b/OutlookOkan/Properties/Resources.de-DE.resx
@@ -978,4 +978,7 @@ Risiko einer Infektion mit einem Virus.</value>
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>Bitte wählen Sie die richtige Datei aus. Fehler:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>Da keine Internetverbindung besteht, ist die Sicherheitsüberprüfung beim Öffnen von E-Mails nicht verfügbar.</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.de-DE.resx
+++ b/OutlookOkan/Properties/Resources.de-DE.resx
@@ -843,7 +843,7 @@ wird diese Funktion angewendet.</value>
     <value>Unbekannt</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>Über das Programm</value>

--- a/OutlookOkan/Properties/Resources.es-ES.resx
+++ b/OutlookOkan/Properties/Resources.es-ES.resx
@@ -976,4 +976,7 @@ riesgo de infección con un virus.</value>
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>Seleccione el archivo correcto. Error:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>Dado que no hay conexión a Internet, la función de comprobación de seguridad no está disponible al abrir el correo electrónico.</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.es-ES.resx
+++ b/OutlookOkan/Properties/Resources.es-ES.resx
@@ -894,9 +894,7 @@ se aplicará esta función.</value>
 * La configuración se reflejará después de reiniciar Outlook.</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>Habilitar esta función puede causar problemas.
-
-* La configuración se reflejará después de reiniciar Outlook.</value>
+    <value>La configuración se reflejará después de reiniciar Outlook.</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>Utilice la función de advertencia al abrir archivos adjuntos.</value>

--- a/OutlookOkan/Properties/Resources.es-ES.resx
+++ b/OutlookOkan/Properties/Resources.es-ES.resx
@@ -841,7 +841,7 @@ se aplicará esta función.</value>
     <value>Desconocido</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>Sobre el programa</value>

--- a/OutlookOkan/Properties/Resources.hi-IN.resx
+++ b/OutlookOkan/Properties/Resources.hi-IN.resx
@@ -889,9 +889,7 @@
 * Outlook को पुनरारंभ करने के बाद सेटिंग्स दिखाई देंगी.</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>इस सुविधा को सक्षम करने से समस्या हो सकती है।
-
-* Outlook को पुनरारंभ करने के बाद सेटिंग्स दिखाई देंगी.</value>
+    <value>Outlook को पुनरारंभ करने के बाद सेटिंग्स दिखाई देंगी.</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>अनुलग्नक खोलते समय चेतावनी सुविधा का उपयोग करें.</value>

--- a/OutlookOkan/Properties/Resources.hi-IN.resx
+++ b/OutlookOkan/Properties/Resources.hi-IN.resx
@@ -836,7 +836,7 @@
     <value>अनजान</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>कार्यक्रम के बारे में</value>

--- a/OutlookOkan/Properties/Resources.hi-IN.resx
+++ b/OutlookOkan/Properties/Resources.hi-IN.resx
@@ -971,4 +971,7 @@
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>कृपया सही फ़ाइल का चयन करें. भूल:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>चूंकि कोई इंटरनेट कनेक्शन नहीं है, इसलिए ई-मेल खोलते समय सुरक्षा जाँच सुविधा उपलब्ध नहीं है।</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.ja-JP.resx
+++ b/OutlookOkan/Properties/Resources.ja-JP.resx
@@ -919,9 +919,7 @@
 ※設定はOutlookを再起動すると反映されます。</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>有効にすると問題が発生する恐れがあります。
-
-※設定はOutlookを再起動すると反映されます。</value>
+    <value>設定はOutlookを再起動すると反映されます。</value>
   </data>
   <data name="SpfDkimWaring2" xml:space="preserve">
     <value>このメールの内容や添付ファイルには十分注意してください。</value>

--- a/OutlookOkan/Properties/Resources.ja-JP.resx
+++ b/OutlookOkan/Properties/Resources.ja-JP.resx
@@ -970,4 +970,8 @@ ZIPファイル内に.oneファイルが含まれており、
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>適切なファイルを選択してください。エラー:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>インターネットに接続されていないため、メールを開く際の安全確認機能は利用できません。
+※インターネットに接続した状態で、Outlookを再起動してください。</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.ja-JP.resx
+++ b/OutlookOkan/Properties/Resources.ja-JP.resx
@@ -362,7 +362,7 @@
     <value>Copyright (C) 2023 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>バージョン 2.8.0.1.2</value>
+    <value>バージョン 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>バージョン情報</value>

--- a/OutlookOkan/Properties/Resources.ko-KR.resx
+++ b/OutlookOkan/Properties/Resources.ko-KR.resx
@@ -969,4 +969,7 @@ zip 파일에는 매크로가 포함 된 Office 파일이 포함되어 있습니
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>올바른 파일을 선택하십시오. 오류:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>인터넷에 연결되어 있지 않기 때문에 이메일을 열 때 안전 확인 기능을 사용할 수 없습니다.</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.ko-KR.resx
+++ b/OutlookOkan/Properties/Resources.ko-KR.resx
@@ -887,9 +887,7 @@
 *Outlook을 다시 시작하면 설정이 반영됩니다.</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>이 기능을 활성화하면 문제가 발생할 수 있습니다.
-
-*Outlook을 다시 시작하면 설정이 반영됩니다.</value>
+    <value>Outlook을 다시 시작하면 설정이 반영됩니다.</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>첨부 파일을 열 때 경고 기능을 사용하십시오.</value>

--- a/OutlookOkan/Properties/Resources.ko-KR.resx
+++ b/OutlookOkan/Properties/Resources.ko-KR.resx
@@ -831,7 +831,7 @@
     <value>알려지지 않은</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>이 프로그램에 대해</value>

--- a/OutlookOkan/Properties/Resources.resx
+++ b/OutlookOkan/Properties/Resources.resx
@@ -970,4 +970,7 @@ risk of infection with a virus.</value>
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>Please select the correct file. Error:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>Since there is no Internet connection, the safety check feature is not available when opening e-mail.</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.resx
+++ b/OutlookOkan/Properties/Resources.resx
@@ -362,7 +362,7 @@
     <value>Copyright (C) 2023 Noraneko Inc.</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>About</value>

--- a/OutlookOkan/Properties/Resources.resx
+++ b/OutlookOkan/Properties/Resources.resx
@@ -921,9 +921,7 @@ If there is no recipient corresponding to the keywords in the body of the e-mail
 *Settings will be reflected after restarting Outlook.</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>Enabling this feature may cause problems.
-
-*Settings will be reflected after restarting Outlook.</value>
+    <value>Settings will be reflected after restarting Outlook.</value>
   </data>
   <data name="SpfDkimWaring2" xml:space="preserve">
     <value>Please be careful with the content and attachments in this email.</value>

--- a/OutlookOkan/Properties/Resources.ru-RU.resx
+++ b/OutlookOkan/Properties/Resources.ru-RU.resx
@@ -840,7 +840,7 @@
     <value>Неизвестно</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>О программе.</value>

--- a/OutlookOkan/Properties/Resources.ru-RU.resx
+++ b/OutlookOkan/Properties/Resources.ru-RU.resx
@@ -893,9 +893,7 @@
 *Настройки будут отражены после перезапуска Outlook.</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>Включение этой функции может вызвать проблемы.
-
-*Настройки будут отражены после перезапуска Outlook.</value>
+    <value>Настройки будут отражены после перезапуска Outlook.</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>Используйте функцию предупреждения при открытии вложений.</value>

--- a/OutlookOkan/Properties/Resources.ru-RU.resx
+++ b/OutlookOkan/Properties/Resources.ru-RU.resx
@@ -975,4 +975,7 @@ ZIP-файл содержит файл Office, содержащий макрос
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>Пожалуйста, выберите правильный файл. Ошибка:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>Поскольку подключение к Интернету отсутствует, функция проверки безопасности недоступна при открытии электронной почты.</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.th-TH.resx
+++ b/OutlookOkan/Properties/Resources.th-TH.resx
@@ -970,4 +970,7 @@ bcc โดยอัตโนมัติ</value>
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>โปรดเลือกไฟล์ที่ถูกต้อง ความผิดพลาด:</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>เนื่องจากไม่มีการเชื่อมต่ออินเทอร์เน็ตคุณสมบัติการตรวจสอบความปลอดภัยจึงไม่สามารถใช้งานได้เมื่อเปิดอีเมล</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.th-TH.resx
+++ b/OutlookOkan/Properties/Resources.th-TH.resx
@@ -888,9 +888,7 @@ bcc โดยอัตโนมัติ</value>
 *การตั้งค่าจะปรากฏขึ้นหลังจากรีสตาร์ท Outlook</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>การเปิดใช้งานคุณสมบัตินี้อาจทําให้เกิดปัญหาได้
-
-*การตั้งค่าจะปรากฏขึ้นหลังจากรีสตาร์ท Outlook</value>
+    <value>การตั้งค่าจะปรากฏขึ้นหลังจากรีสตาร์ท Outlook</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>ใช้คุณสมบัติคําเตือนเมื่อเปิดไฟล์แนบ</value>

--- a/OutlookOkan/Properties/Resources.th-TH.resx
+++ b/OutlookOkan/Properties/Resources.th-TH.resx
@@ -835,7 +835,7 @@ bcc โดยอัตโนมัติ</value>
     <value>ไม่รู้จัก</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>เกี่ยวกับโปรแกรมนี้</value>

--- a/OutlookOkan/Properties/Resources.zh-CN.resx
+++ b/OutlookOkan/Properties/Resources.zh-CN.resx
@@ -834,7 +834,7 @@
     <value>不详</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>软件信息</value>

--- a/OutlookOkan/Properties/Resources.zh-CN.resx
+++ b/OutlookOkan/Properties/Resources.zh-CN.resx
@@ -887,9 +887,7 @@
 *设置将在重新启动 Outlook 后反映出来。</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>启用此功能可能会导致问题。
-
-*设置将在重新启动 Outlook 后反映出来。</value>
+    <value>设置将在重新启动 Outlook 后反映出来。</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>打开附件时使用警告功能。</value>

--- a/OutlookOkan/Properties/Resources.zh-CN.resx
+++ b/OutlookOkan/Properties/Resources.zh-CN.resx
@@ -969,4 +969,7 @@ zip 文件包含一个包含宏和
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>请选择正确的文件。错误：</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>由于没有互联网连接，因此打开电子邮件时无法使用安全检查功能。</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.zh-TW.resx
+++ b/OutlookOkan/Properties/Resources.zh-TW.resx
@@ -887,9 +887,7 @@
 *設置將在重新啟動 Outlook 后反映出來。</value>
   </data>
   <data name="SettingExampleSecurityForReceivedMail" xml:space="preserve">
-    <value>啟用此功能可能會導致問題。
-
-*設置將在重新啟動 Outlook 后反映出來。</value>
+    <value>設置將在重新啟動 Outlook 后反映出來。</value>
   </data>
   <data name="IsEnableWarningFeatureWhenOpeningAttachments" xml:space="preserve">
     <value>打開附件時使用警告功能。</value>

--- a/OutlookOkan/Properties/Resources.zh-TW.resx
+++ b/OutlookOkan/Properties/Resources.zh-TW.resx
@@ -969,4 +969,7 @@ zip 檔包含一個包含宏和
   <data name="ImportErrorOfAllSettings" xml:space="preserve">
     <value>請選擇正確的檔。錯誤：</value>
   </data>
+  <data name="IsNoInternetCantUseSecurityForReceivedMail" xml:space="preserve">
+    <value>由於沒有互聯網連接，因此打開電子郵件時無法使用安全檢查功能。</value>
+  </data>
 </root>

--- a/OutlookOkan/Properties/Resources.zh-TW.resx
+++ b/OutlookOkan/Properties/Resources.zh-TW.resx
@@ -834,7 +834,7 @@
     <value>不詳</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value>Version 2.8.0.1.2</value>
+    <value>Version 2.8.1</value>
   </data>
   <data name="VersionInfo" xml:space="preserve">
     <value>軟件信息</value>

--- a/OutlookOkan/ThisAddIn.cs
+++ b/OutlookOkan/ThisAddIn.cs
@@ -51,26 +51,33 @@ namespace OutlookOkan
             LoadSecurityForReceivedMail();
             if (_securityForReceivedMail.IsEnableSecurityForReceivedMail)
             {
-                _mapiNamespace = Application.GetNamespace("MAPI");
-                _excludedFolderNames = new HashSet<string>{
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderCalendar).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderContacts).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderDrafts).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderJournal).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderNotes).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderOutbox).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderRssFeeds).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderSentMail).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderServerFailures).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderLocalFailures).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderSyncIssues).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderTasks).Name,
-                    _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderToDo).Name
-                };
+                try
+                {
+                    _mapiNamespace = Application.GetNamespace("MAPI");
+                    _excludedFolderNames = new HashSet<string>{
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderCalendar).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderContacts).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderDrafts).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderJournal).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderNotes).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderOutbox).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderRssFeeds).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderSentMail).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderServerFailures).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderLocalFailures).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderSyncIssues).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderTasks).Name,
+                        _mapiNamespace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderToDo).Name
+                    };
 
-                LoadAlertKeywordOfSubjectWhenOpeningMailsData();
-                _currentExplorer = Application.ActiveExplorer();
-                _currentExplorer.SelectionChange += CurrentExplorer_SelectionChange;
+                    LoadAlertKeywordOfSubjectWhenOpeningMailsData();
+                    _currentExplorer = Application.ActiveExplorer();
+                    _currentExplorer.SelectionChange += CurrentExplorer_SelectionChange;
+                }
+                catch (Exception)
+                {
+                    MessageBox.Show(Properties.Resources.IsNoInternetCantUseSecurityForReceivedMail, Properties.Resources.AppName, MessageBoxButton.OK, MessageBoxImage.Error);
+                }
             }
 
             _inspectors = Application.Inspectors;

--- a/OutlookOkan/ThisAddIn.cs
+++ b/OutlookOkan/ThisAddIn.cs
@@ -96,9 +96,14 @@ namespace OutlookOkan
             var selection = currentExplorer.Selection;
             if (selection is null || selection.Count != 1) return;
             if (!(selection[1] is Outlook.MailItem selectedMail)) return;
+            if (_currentMailItemEntryId == selectedMail.EntryID) return;
+
+            if (_currentMailItem != null)
+            {
+                _currentMailItem.BeforeAttachmentRead -= BeforeAttachmentRead;
+            }
 
             _currentMailItem = selectedMail;
-            if (_currentMailItemEntryId == _currentMailItem.EntryID) return;
 
             _currentMailItemEntryId = _currentMailItem.EntryID;
 
@@ -156,11 +161,6 @@ namespace OutlookOkan
             //添付ファイルを開くときの警告機能
             if (_securityForReceivedMail.IsEnableWarningFeatureWhenOpeningAttachments && selectedMail.Attachments.Count != 0)
             {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
-                Thread.Sleep(10);
-
                 _currentMailItem.BeforeAttachmentRead -= BeforeAttachmentRead;
                 _currentMailItem.BeforeAttachmentRead += BeforeAttachmentRead;
             }
@@ -363,15 +363,13 @@ namespace OutlookOkan
                 {
                     _ = Marshal.ReleaseComObject(currentItem);
                     currentItem = null;
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                    GC.Collect();
                 }
 
-                _ = Marshal.ReleaseComObject(inspector);
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
+                if (inspector != null)
+                {
+                    _ = Marshal.ReleaseComObject(inspector);
+                    inspector = null;
+                }
             };
         }
 

--- a/OutlookOkan/ThisAddIn.cs
+++ b/OutlookOkan/ThisAddIn.cs
@@ -404,6 +404,8 @@ namespace OutlookOkan
 
             //Moderationでの返信には何もしない。(キャンセルすると、承認や非承認ができなくなる場合があるため)
             if (((dynamic)item).MessageClass == "IPM.Note.Microsoft.Approval.Reply.Approve" || ((dynamic)item).MessageClass == "IPM.Note.Microsoft.Approval.Reply.Reject") return;
+            //会議の出欠の返信には何もしない。
+            if (((dynamic)item).MessageClass == "IPM.Schedule.Meeting.Resp.Pos" || ((dynamic)item).MessageClass == "IPM.Schedule.Meeting.Resp.Tent" || ((dynamic)item).MessageClass == "IPM.Schedule.Meeting.Resp.Neg") return;
 
             var type = typeof(Outlook.MailItem);
             //何らかの問題で確認画面が表示されないと、意図せずメールが送られてしまう恐れがあるため、念のための処理。

--- a/OutlookOkan/ThisAddIn.cs
+++ b/OutlookOkan/ThisAddIn.cs
@@ -375,6 +375,17 @@ namespace OutlookOkan
         /// <param name="cancel">Cancel</param>
         private void Application_ItemSend(object item, ref bool cancel)
         {
+            try
+            {
+                var activeWindow = Globals.ThisAddIn.Application.ActiveWindow();
+                _ = new NativeMethods(activeWindow).Handle;
+            }
+            catch (Exception)
+            {
+                //Send Mail.
+                return;
+            }
+
             //Outlook起動後にユーザが設定を変更する可能性があるため、毎回ユーザ設定をロード。
             LoadGeneralSetting(false);
             if (!(_generalSetting.LanguageCode is null))


### PR DESCRIPTION
## 不具合修正

- Outlook起動時にインターネットに接続されていない場合、アドインが動作しなくなる場合がある問題を修正

- タスク依頼で存在しない添付ファイルが表示される問題を修正

- タスク依頼で適切にFromを取得できない場合がある問題を修正

- 添付ファイルを開く際の警告機能を有効にしている場合の不具合修正や改善   
  - Outlookから開いた添付ファイルが勝手に閉じられてしまう場合のある問題を修正
  - MS Officeファイルが同じウインドウで開けない場合のある問題を修正
  - 動作速度と安定性を向上 (不要な処理を削除)

- 添付ファイルのサイズがキロバイト未満でも、サイズが正しく表示されるよう修正


## その他

- Outlookの画面が表示されていない状態でメールが送信された場合、アドインでは何もしないよう仕様変更 (暫定処置)  
  ※VBスクリプトからOutlookを操作してメールを送信する場合など

- 会議招待の出欠(返信)には何もしないよう仕様変更 (暫定処置)
 
- 一部の表記を修正

