### PR TITLE
確認ウィンドウのボタンが警告多数時に隠れる問題の修正

### DIFF
--- a/OutlookOkan/Views/ConfirmationWindow.xaml
+++ b/OutlookOkan/Views/ConfirmationWindow.xaml
@@ -24,7 +24,7 @@
             <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ConfirmationMessage1, Mode=OneWay}" FontSize="12.5" Padding="0" />
             <Label Content="{Binding Source={x:Static services:ResourceService.Instance}, Path=Resources.ConfirmationMessage2, Mode=OneWay}" FontSize="11.5" Padding="0" Margin="0,3" />
         </StackPanel>
-        <Grid Grid.Column="0" Grid.Row="1" Margin="8,7,8,8">
+        <Grid Grid.Column="0" Grid.Row="1" Margin="8,7,8,8" MaxHeight="200">
             <GroupBox Header="{Binding AlertCount}" FontSize="11.5" Padding="3,3,3,3">
                 <DataGrid x:Name="AlertGrid" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" BorderBrush="#FFD5DFE5" HeadersVisibility="None" ItemsSource="{Binding Alerts,Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="false" CanUserDeleteRows="false" CanUserResizeColumns="false" CanUserResizeRows="false" CanUserSortColumns="false" HorizontalGridLinesBrush="#FFD5DFE5" VerticalGridLinesBrush="#FFD5DFE5">
                     <DataGrid.ItemContainerStyle>


### PR DESCRIPTION
## 概要

送信確認ウィンドウで警告(Alert)が多数表示されると、警告セクションが青天井に伸びて「送信」「キャンセル」ボタンがウィンドウ下部の枠外に押し出され、操作できなくなる問題を修正します。
問題なければ取り込んでいただけると大変助かります。

## 原因

確認ウィンドウ(`ConfirmationWindow.xaml`)のルート Grid は行構成が

| Row | 内容 | 高さ |
|-----|------|------|
| 0 | メッセージ | Auto |
| 1 | **警告セクション** | **Auto(上限なし)** |
| 2 | 宛先/添付/本文 | *(残り) |
| 3 | 送信/キャンセルボタン | Auto |

となっており、ウィンドウは `Height="590" MinHeight="590"` の固定高です。
警告セクション(Row 1)が `Height="Auto"` で上限を持たないため、警告件数が増えると縦方向に伸び続け、固定高のウィンドウ内で最下部のボタン(Row 3)を枠外へ押し出していました。

## 修正内容

警告セクションの Grid に `MaxHeight="200"` を設定し、高さの上限を設けました。
上限を超えた場合は既存の `VerticalScrollBarVisibility="Visible"` により内部スクロールで表示されるため、警告が何件あっても送信/キャンセルボタンが常にウィンドウ下部に表示されます。

## 動作確認

外部ドメイン宛先を多数(30件)指定し、宛先数ぶんの警告が出る状態で確認ウィンドウを表示し、classic版OutlookでVS(Community Edition)でビルド。ローカルで動作確認しました。
（当方がこの環境の開発に不慣れなため、不備があればご指摘ください）

| 項目                  | 修正前               | 修正後                          |
| --------------------- | -------------------- | ------------------------------- |
| 警告セクション        | 際限なく伸びる       | 高さ200で頭打ち・内部スクロール |
| 送信/キャンセルボタン | 枠外に隠れて操作不可 | 常に表示される                  |

なお、当初は「UIのテキストサイズ拡大時のみ発生」と考えていましたが、**拡大率100%のままでも警告が多数あれば発生する**ことを確認しています。本修正はいずれのケースも解消します。

## スクリーンショット
※どちらもGenerateCheckListFromMailに一時コードを差し込み、全アドレスに警告をいれるようにして再現させています。
### Before
<img width="789" height="573" alt="image" src="https://github.com/user-attachments/assets/3b91ec02-6ee9-419e-a756-2fc7795f0902" />

### After
<img width="784" height="573" alt="image" src="https://github.com/user-attachments/assets/209a3737-546b-4188-a89e-867033694af0" />

